### PR TITLE
Biased Economizer Sensor Offset - OAT

### DIFF
--- a/fault_measures_2017/BiasedEconomizerSensorOutdoorT/measure.rb
+++ b/fault_measures_2017/BiasedEconomizerSensorOutdoorT/measure.rb
@@ -10,9 +10,10 @@
 require "#{File.dirname(__FILE__)}/resources/ControllerOutdoorAirFlow_T"
 
 $allchoices = '* ALL Controller:OutdoorAir *'
+$faulttype = 'OAT'				   
 
 # start the measure
-class BiasedEconomizerSensorReturnRH < OpenStudio::Ruleset::WorkspaceUserScript
+class BiasedEconomizerSensorOAT < OpenStudio::Ruleset::WorkspaceUserScript
 
   # human readable name
   def name
@@ -165,15 +166,18 @@ class BiasedEconomizerSensorReturnRH < OpenStudio::Ruleset::WorkspaceUserScript
           #main program differs as the options at controlleroutdoorair differs
           #create a new string for the main program to start appending the required
           #EMS routine to it
-                    
-          main_body = econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorair, [0.0, out_t_bias])
+          ##################################################
+		  oacontrollername = econ_choice.clone.gsub!(/[^0-9A-Za-z]/, '')
+		  ##################################################        
+		  
+          main_body = econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorair, [0.0, out_t_bias], oacontrollername)
           
           string_objects << main_body
           
           #append other objects
           strings_objects = econ_rh_sensor_bias_ems_other(string_objects, workspace, bias_sensor, controlleroutdoorair)
 		  ##################################################
-		  strings_objects = faultintensity_adjustmentfactor(string_objects, time_constant, time_step, start_month, start_date, start_time, end_month, end_date, end_time)
+		  strings_objects = faultintensity_adjustmentfactor(string_objects, time_constant, time_step, start_month, start_date, start_time, end_month, end_date, end_time, oacontrollername)
 		  ##################################################
           
           #add all of the strings to workspace to create IDF objects
@@ -204,4 +208,4 @@ class BiasedEconomizerSensorReturnRH < OpenStudio::Ruleset::WorkspaceUserScript
 end
 
 # register the measure to be used by the application
-BiasedEconomizerSensorReturnRH.new.registerWithApplication
+BiasedEconomizerSensorOAT.new.registerWithApplication

--- a/fault_measures_2017/BiasedEconomizerSensorOutdoorT/measure.xml
+++ b/fault_measures_2017/BiasedEconomizerSensorOutdoorT/measure.xml
@@ -1,11 +1,11 @@
 <measure>
   <schema_version>3.0</schema_version>
-  <name>biased_economizer_sensor_return_rh</name>
+  <name>biased_economizer_sensor_oat</name>
   <uid>75ad65c1-1f17-4fa3-be05-13a3bb415fbe</uid>
-  <version_id>3f6893cc-b8ac-4f3a-b86f-fe7df19491c7</version_id>
-  <version_modified>20180313T161758Z</version_modified>
+  <version_id>e929184a-c7dd-4c70-9b7a-59e8c162fc8e</version_id>
+  <version_modified>20180315T181112Z</version_modified>
   <xml_checksum>B7427881</xml_checksum>
-  <class_name>BiasedEconomizerSensorReturnRH</class_name>
+  <class_name>BiasedEconomizerSensorOAT</class_name>
   <display_name>Biased Economizer Sensor: Outdoor Temperature</display_name>
   <description>When sensors drift and are not regularly calibrated, it causes a bias. Sensor readings often drift from their calibration with age, causing equipment control algorithms to produce outputs that deviate from their intended function. This measure simulates the biased economizer sensor (outdoor temperature) by modifying Controller:OutdoorAir object in EnergyPlus assigned to the heating and cooling system. The fault intensity (F) for this fault is defined as the biased temperature level (K), which is also specified as one of the inputs.</description>
   <modeler_description>Nine user inputs are required and, based on these user inputs, the outdoor air temperature reading in the economizer will be replaced by the equation below, where ToaF is the biased outdoor air temperature reading, Toa is the actual outdoor air temperature, F is the fault intensity and AF is the adjustment factor. ToaF = Toa + F*AF. To use this measure, choose the Controller:OutdoorAir object to be faulted. Set the level of temperature sensor bias in K that you want at the outdoors for the economizer during the simulation period. For example, setting 2 means the sensor is reading 28C when the actual temperature is 26C. The time required for the fault to reach the full level is only required when user wants to model dynamic fault evolution. If dynamic fault evolution is not necessary for the user, it can be defined as zero and the fault intensity will be imposed as a step function with user defined value. However, by defining the time required for the fault to reach the full level, fault starting month/date/time and fault ending month/date/time, the adjustment factor AF is calculated at each time step starting from the starting month/date/time to gradually impose fault intensity based on the user specified time frame. AF is calculated as follows, AF_current = AF_previous + dt/tau where AF_current is the adjustment factor calculated based on the previously calculated adjustment factor (AF_previous), simulation timestep (dt) and the time required for the fault to reach the full level (tau).</modeler_description>
@@ -117,12 +117,6 @@
       <checksum>435C6B82</checksum>
     </file>
     <file>
-      <filename>ControllerOutdoorAirFlow_T.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>A31AFF13</checksum>
-    </file>
-    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>1.5.0</identifier>
@@ -131,7 +125,13 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>7B2B01B6</checksum>
+      <checksum>71357120</checksum>
+    </file>
+    <file>
+      <filename>ControllerOutdoorAirFlow_T.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>D8E96669</checksum>
     </file>
   </files>
 </measure>

--- a/fault_measures_2017/BiasedEconomizerSensorOutdoorT/resources/ControllerOutdoorAirFlow_T.rb
+++ b/fault_measures_2017/BiasedEconomizerSensorOutdoorT/resources/ControllerOutdoorAirFlow_T.rb
@@ -5,7 +5,7 @@
 
 require_relative 'misc_eplus_func'
 
-def faultintensity_adjustmentfactor(string_objects, time_constant, time_step, start_month, start_date, start_time, end_month, end_date, end_time)
+def faultintensity_adjustmentfactor(string_objects, time_constant, time_step, start_month, start_date, start_time, end_month, end_date, end_time, oacontrollername)
 
   #append transient fault adjustment factor
   ##################################################
@@ -78,27 +78,27 @@ def faultintensity_adjustmentfactor(string_objects, time_constant, time_step, st
       SET EndTime = T_EM + (ED-1)*24 + ET,  !- A62
       IF (ActualTime>=StartTime) && (ActualTime<=EndTime),  !- A63
       SET AF_previous = @TrendValue AF_trend 1,  !- A64			
-      SET AF_current = AF_previous + dt/tau,  !- A65			
-      IF AF_current>1.0,       !- A66
-      SET AF_current = 1.0,    !- A67
+      SET AF_current_#{$faulttype}_#{oacontrollername} = AF_previous + dt/tau,  !- A65			
+      IF AF_current_#{$faulttype}_#{oacontrollername}>1.0,       !- A66
+      SET AF_current_#{$faulttype}_#{oacontrollername} = 1.0,    !- A67
       ENDIF,                   !- A68
       IF AF_previous>=1.0,     !- A69
-      SET AF_current = 1.0,    !- A70
+      SET AF_current_#{$faulttype}_#{oacontrollername} = 1.0,    !- A70
       ENDIF,                   !- A71
       ELSE,                    !- A72
       SET AF_previous = 0.0,   !- A73
-      SET AF_current = 0.0,    !- A74
+      SET AF_current_#{$faulttype}_#{oacontrollername} = 0.0,    !- A74
       ENDIF;                   !- A75
   "
   string_objects << "
     EnergyManagementSystem:GlobalVariable,				
-      AF_current;              !- Erl Variable 1 Name
+      AF_current_#{$faulttype}_#{oacontrollername};              !- Erl Variable 1 Name
   "
 			  
   string_objects << "
     EnergyManagementSystem:TrendVariable,				
       AF_Trend,                !- Name
-      AF_current,              !- EMS Variable Name
+      AF_current_#{$faulttype}_#{oacontrollername},              !- EMS Variable Name
       1;                       !- Number of Timesteps to be Logged
   "
 			
@@ -114,7 +114,7 @@ def faultintensity_adjustmentfactor(string_objects, time_constant, time_step, st
   
 end
 
-def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorair, t_bias=[0, 0])
+def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorair, t_bias=[0, 0], oacontrollername)
 
   #workspace is the Workspace object in EnergyPlus Measure script
   
@@ -161,7 +161,7 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
   end
   if bias_sensor.eql?("RET")
     main_body = main_body+"
-      SET RETTmp = "+name_cut(econ_choice)+"RETTemp1#{bias_sensor}_T"+ret_str_num+"*AF_current, !- <none>
+      SET RETTmp = "+name_cut(econ_choice)+"RETTemp1#{bias_sensor}_T"+ret_str_num+"*AF_current_#{$faulttype}_#{oacontrollername}, !- <none>
       SET RETHumRat = "+name_cut(econ_choice)+"RETOmega1#{bias_sensor}_T, !- <none>
       SET OATmp = "+name_cut(econ_choice)+"OATTemp1#{bias_sensor}_T, !- <none>
       SET OAHumRat = "+name_cut(econ_choice)+"OATOmega1#{bias_sensor}_T, !- <none>
@@ -183,7 +183,7 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
     main_body = main_body+"
 	  SET RETTmp = "+name_cut(econ_choice)+"RETTemp1#{bias_sensor}_T, !- <none>
       SET RETHumRat = "+name_cut(econ_choice)+"RETOmega1#{bias_sensor}_T, !- <none>
-      SET OATmp = "+name_cut(econ_choice)+"OATTemp1#{bias_sensor}_T"+oa_str_num+"*AF_current, !- <none>
+      SET OATmp = "+name_cut(econ_choice)+"OATTemp1#{bias_sensor}_T"+oa_str_num+"*AF_current_#{$faulttype}_#{oacontrollername}, !- <none>
       SET OAHumRat = "+name_cut(econ_choice)+"OATOmega1#{bias_sensor}_T, !- <none>
       SET PTmp = "+name_cut(econ_choice)+"RETPressure1#{bias_sensor}_T, !- <none>
       IF PTmp < DELTASMALL, !- <none>
@@ -202,9 +202,9 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
     "
   else  #for bias in both sensors
     main_body = main_body+"
-      SET RETTmp = "+name_cut(econ_choice)+"RETTemp1#{bias_sensor}_T"+ret_str_num+"*AF_current, !- <none>
+      SET RETTmp = "+name_cut(econ_choice)+"RETTemp1#{bias_sensor}_T"+ret_str_num+"*AF_current_#{$faulttype}_#{oacontrollername}, !- <none>
       SET RETHumRat = "+name_cut(econ_choice)+"RETOmega1#{bias_sensor}_T, !- <none>
-      SET OATmp = "+name_cut(econ_choice)+"OATTemp1#{bias_sensor}_T"+oa_str_num+"*AF_current, !- <none>
+      SET OATmp = "+name_cut(econ_choice)+"OATTemp1#{bias_sensor}_T"+oa_str_num+"*AF_current_#{$faulttype}_#{oacontrollername}, !- <none>
       SET OAHumRat = "+name_cut(econ_choice)+"OATOmega1#{bias_sensor}_T, !- <none>
       SET PTmp = "+name_cut(econ_choice)+"RETPressure1#{bias_sensor}_T, !- <none>
       IF PTmp < DELTASMALL, !- <none>


### PR DESCRIPTION
Small update on previous EMS dynamic fault evolution fault code. Added additional strings to the AF_current parameter so that fault measure don't step on each other, when multiple fault measures (multiple faults' dynamic fault evolution) are applied in the simulation.