### PR TITLE
Return Air Duct Leakages

### DIFF
--- a/fault_measures_2017/ReturnAirDuctLeakages/measure.rb
+++ b/fault_measures_2017/ReturnAirDuctLeakages/measure.rb
@@ -10,6 +10,7 @@
 require "#{File.dirname(__FILE__)}/resources/ControllerOutdoorAirFlow_DuctLeakage"
 
 $allchoices = '* ALL Controller:OutdoorAir *'
+$faulttype = 'DL'
 
 # start the measure
 class ReturnAirDuctLeakages < OpenStudio::Ruleset::WorkspaceUserScript
@@ -163,14 +164,17 @@ class ReturnAirDuctLeakages < OpenStudio::Ruleset::WorkspaceUserScript
           #main program differs as the options at controlleroutdoorair differs
           #create a new string for the main program to start appending the required
           #EMS routine to it
+		  ##################################################
+		  oacontrollername = econ_choice.clone.gsub!(/[^0-9A-Za-z]/, '')
+		  ################################################## 
                     
-          main_body = econ_ductleakage_ems_main_body(workspace, controlleroutdoorair, leak_ratio)
+          main_body = econ_ductleakage_ems_main_body(workspace, controlleroutdoorair, leak_ratio, oacontrollername)
           string_objects << main_body
            
           #append other objects
           strings_objects = econ_ductleakage_ems_other(string_objects, workspace, controlleroutdoorair)
 		  ##################################################
-		  strings_objects = faultintensity_adjustmentfactor(string_objects, time_constant, time_step, start_month, start_date, start_time, end_month, end_date, end_time)
+		  strings_objects = faultintensity_adjustmentfactor(string_objects, time_constant, time_step, start_month, start_date, start_time, end_month, end_date, end_time, oacontrollername)
 		  ##################################################
 
           #add all of the strings to workspace to create IDF objects

--- a/fault_measures_2017/ReturnAirDuctLeakages/measure.xml
+++ b/fault_measures_2017/ReturnAirDuctLeakages/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>return_air_duct_leakages</name>
   <uid>e28746df-aa8c-4f6e-a2be-6e2ff3c5e7dd</uid>
-  <version_id>ed62d305-ec3d-476a-97a0-3cfb3eeb59e8</version_id>
-  <version_modified>20180313T161800Z</version_modified>
+  <version_id>cb5f5090-026c-4276-b9d2-30d064a29c91</version_id>
+  <version_modified>20180315T174034Z</version_modified>
   <xml_checksum>FAAEB4D1</xml_checksum>
   <class_name>ReturnAirDuctLeakages</class_name>
   <display_name>Return Air Duct Leakages</display_name>
@@ -120,7 +120,7 @@
       <filename>ControllerOutdoorAirFlow_DuctLeakage.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>EEED55FE</checksum>
+      <checksum>E872BB8F</checksum>
     </file>
     <file>
       <version>
@@ -131,7 +131,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>13E7D1CB</checksum>
+      <checksum>2680767C</checksum>
     </file>
   </files>
 </measure>

--- a/fault_measures_2017/ReturnAirDuctLeakages/resources/ControllerOutdoorAirFlow_DuctLeakage.rb
+++ b/fault_measures_2017/ReturnAirDuctLeakages/resources/ControllerOutdoorAirFlow_DuctLeakage.rb
@@ -5,7 +5,7 @@
 
 require_relative 'misc_eplus_func'
 
-def faultintensity_adjustmentfactor(string_objects, time_constant, time_step, start_month, start_date, start_time, end_month, end_date, end_time)
+def faultintensity_adjustmentfactor(string_objects, time_constant, time_step, start_month, start_date, start_time, end_month, end_date, end_time, oacontrollername)
 
   #append transient fault adjustment factor
   ##################################################
@@ -78,27 +78,27 @@ def faultintensity_adjustmentfactor(string_objects, time_constant, time_step, st
       SET EndTime = T_EM + (ED-1)*24 + ET,  !- A62
       IF (ActualTime>=StartTime) && (ActualTime<=EndTime),  !- A63
       SET AF_previous = @TrendValue AF_trend 1,  !- A64			
-      SET AF_current = AF_previous + dt/tau,  !- A65			
-      IF AF_current>1.0,       !- A66
-      SET AF_current = 1.0,    !- A67
+      SET AF_current_#{$faulttype}_#{oacontrollername} = AF_previous + dt/tau,  !- A65			
+      IF AF_current_#{$faulttype}_#{oacontrollername}>1.0,       !- A66
+      SET AF_current_#{$faulttype}_#{oacontrollername} = 1.0,    !- A67
       ENDIF,                   !- A68
       IF AF_previous>=1.0,     !- A69
-      SET AF_current = 1.0,    !- A70
+      SET AF_current_#{$faulttype}_#{oacontrollername} = 1.0,    !- A70
       ENDIF,                   !- A71
       ELSE,                    !- A72
       SET AF_previous = 0.0,   !- A73
-      SET AF_current = 0.0,    !- A74
+      SET AF_current_#{$faulttype}_#{oacontrollername} = 0.0,    !- A74
       ENDIF;                   !- A75
   "
   string_objects << "
     EnergyManagementSystem:GlobalVariable,				
-      AF_current;              !- Erl Variable 1 Name
+      AF_current_#{$faulttype}_#{oacontrollername};              !- Erl Variable 1 Name
   "
 			  
   string_objects << "
     EnergyManagementSystem:TrendVariable,				
       AF_Trend,                !- Name
-      AF_current,              !- EMS Variable Name
+      AF_current_#{$faulttype}_#{oacontrollername},              !- EMS Variable Name
       1;                       !- Number of Timesteps to be Logged
   "
 			
@@ -114,7 +114,7 @@ def faultintensity_adjustmentfactor(string_objects, time_constant, time_step, st
   
 end
 
-def econ_ductleakage_ems_main_body(workspace, controlleroutdoorair, leak_ratio)
+def econ_ductleakage_ems_main_body(workspace, controlleroutdoorair, leak_ratio, oacontrollername)
 
   #workspace is the Workspace object in EnergyPlus Measure script
   #controlleroutdoorair is a workspace object representing the chose controller outdorrair object
@@ -585,7 +585,7 @@ def econ_ductleakage_ems_main_body(workspace, controlleroutdoorair, leak_ratio)
     SET OA_NEW = @Min MDOT_OA_MAX OA_NEW, !- <none>
     SET FinalFlow = OA_NEW, !- <none>
     ENDIF, !- <none>
-    SET "+name_cut(econ_choice)+"MDOT_OA = FinalFlow + "+name_cut(econ_choice)+"MixAirFlow_CTRL*("+leakratio+")*AF_current; !- <none>
+    SET "+name_cut(econ_choice)+"MDOT_OA = FinalFlow + "+name_cut(econ_choice)+"MixAirFlow_CTRL*("+leakratio+")*AF_current_#{$faulttype}_#{oacontrollername}; !- <none>
   "
   
   return main_body


### PR DESCRIPTION
Small update on previous EMS dynamic fault evolution fault code. Added additional strings to the AF_current parameter so that fault measure don't step on each other, when multiple fault measures (multiple faults' dynamic fault evolution) are applied in the simulation.