### PR TITLE
Lighting setback error fault intensity modified

### DIFF
--- a/fault_measures_2017/LightingSetbackErrorEarlyTermination/measure.rb
+++ b/fault_measures_2017/LightingSetbackErrorEarlyTermination/measure.rb
@@ -122,7 +122,7 @@ class LightingSetbackErrorEarlyTermination < OpenStudio::Ruleset::ModelUserScrip
       # apply fault
       lights.each do |light|
 	next if not light.size > 0
-        results = applyfaulttolight_no_setback_ext_hr_morning(light, ext_hr, start_month, end_month, dayofweek, runner, setpoint_values, model)
+        results = applyfaulttolight_no_setback_ext_hr_morning(light, -1*ext_hr, start_month, end_month, dayofweek, runner, setpoint_values, model)
 
         # populate hash for min max values across zones
         if not results == false


### PR DESCRIPTION
fault intensity for the Lighting Setback Error: Early Termination was modified (just flipping sign-convention) to have the same meaning described in the fault intensity definition.