### PR TITLE
Fault model updates

### DIFF
--- a/fault_measures_2017/BiasedEconomizerSensorOutdoorRH/measure.xml
+++ b/fault_measures_2017/BiasedEconomizerSensorOutdoorRH/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>biased_economizer_sensor_outdoor_rh</name>
   <uid>cb5d34a2-7980-44bb-8a41-1f2cb262fd81</uid>
-  <version_id>0958e085-5430-44a3-b391-9fc679697f99</version_id>
-  <version_modified>20190411T215033Z</version_modified>
+  <version_id>8529a511-908e-4348-b311-c2c51a1aa354</version_id>
+  <version_modified>20190415T161852Z</version_modified>
   <xml_checksum>B7427881</xml_checksum>
   <class_name>BiasedEconomizerSensorOutdoorRH</class_name>
   <display_name>Biased Economizer Sensor: Outdoor RH</display_name>
@@ -131,7 +131,7 @@
       <filename>ControllerOutdoorAirFlow_RH.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>1C0D0879</checksum>
+      <checksum>E613A825</checksum>
     </file>
   </files>
 </measure>

--- a/fault_measures_2017/BiasedEconomizerSensorOutdoorRH/measure.xml
+++ b/fault_measures_2017/BiasedEconomizerSensorOutdoorRH/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>biased_economizer_sensor_outdoor_rh</name>
   <uid>cb5d34a2-7980-44bb-8a41-1f2cb262fd81</uid>
-  <version_id>779f5d8d-8100-48ae-ab2c-a37a2a75235d</version_id>
-  <version_modified>20190410T223831Z</version_modified>
+  <version_id>d70941f8-1e24-4801-991b-41313591888f</version_id>
+  <version_modified>20190411T202926Z</version_modified>
   <xml_checksum>B7427881</xml_checksum>
   <class_name>BiasedEconomizerSensorOutdoorRH</class_name>
   <display_name>Biased Economizer Sensor: Outdoor RH</display_name>
@@ -117,12 +117,6 @@
       <checksum>435C6B82</checksum>
     </file>
     <file>
-      <filename>ControllerOutdoorAirFlow_RH.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>83D101AC</checksum>
-    </file>
-    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>1.5.0</identifier>
@@ -132,6 +126,12 @@
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
       <checksum>A2E63E6E</checksum>
+    </file>
+    <file>
+      <filename>ControllerOutdoorAirFlow_RH.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>87384479</checksum>
     </file>
   </files>
 </measure>

--- a/fault_measures_2017/BiasedEconomizerSensorOutdoorRH/measure.xml
+++ b/fault_measures_2017/BiasedEconomizerSensorOutdoorRH/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>biased_economizer_sensor_outdoor_rh</name>
   <uid>cb5d34a2-7980-44bb-8a41-1f2cb262fd81</uid>
-  <version_id>d70941f8-1e24-4801-991b-41313591888f</version_id>
-  <version_modified>20190411T202926Z</version_modified>
+  <version_id>0958e085-5430-44a3-b391-9fc679697f99</version_id>
+  <version_modified>20190411T215033Z</version_modified>
   <xml_checksum>B7427881</xml_checksum>
   <class_name>BiasedEconomizerSensorOutdoorRH</class_name>
   <display_name>Biased Economizer Sensor: Outdoor RH</display_name>
@@ -131,7 +131,7 @@
       <filename>ControllerOutdoorAirFlow_RH.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>87384479</checksum>
+      <checksum>1C0D0879</checksum>
     </file>
   </files>
 </measure>

--- a/fault_measures_2017/BiasedEconomizerSensorOutdoorRH/resources/ControllerOutdoorAirFlow_RH.rb
+++ b/fault_measures_2017/BiasedEconomizerSensorOutdoorRH/resources/ControllerOutdoorAirFlow_RH.rb
@@ -136,23 +136,23 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
   econ_short_name = name_cut(econ_choice)
   main_body = "
     EnergyManagementSystem:Program,
-      RH_BIAS"+name_cut(econ_choice)+"#{bias_sensor}_RH, !- Name
+      RH_BIAS"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype}, !- Name
       SET DELTASMALL = 0.00001, !- Program Line 1
       SET SMALLMASSFLOW = 0.001, !- Program Line 2
       SET SMALLVOLFLOW = 0.001, !- Program Line 3
       SET HIGHHUMCTRL = False, !- <none>
       SET NIGHTVENT = False, !- <none>
       SET ECON_OP = True, !- <none>
-      SET MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_RH = "+name_cut(econ_choice)+"MixAirFlow_CTRL#{bias_sensor}_RH, !- <none>
-      IF MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_RH < SMALLMASSFLOW, !- Check if the duct has airflow
+      SET MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = "+name_cut(econ_choice)+"MixAirFlow_CTRL#{bias_sensor}_#{$faulttype}, !- <none>
+      IF MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} < SMALLMASSFLOW, !- Check if the duct has airflow
       SET FinalFlow = 0.00, !- <none>
       RETURN, !- <none>
       ENDIF, !- <none>
-      SET RETTmp = "+name_cut(econ_choice)+"RETTemp1#{bias_sensor}_RH, !- <none>
-      SET RETHumRat = "+name_cut(econ_choice)+"RETOmega1#{bias_sensor}_RH, !- <none>
-      SET OATmp = "+name_cut(econ_choice)+"OATTemp1#{bias_sensor}_RH, !- <none>
-      SET OAHumRat = "+name_cut(econ_choice)+"OATOmega1#{bias_sensor}_RH, !- <none>
-      SET PTmp = "+name_cut(econ_choice)+"RETPressure1#{bias_sensor}_RH, !- <none>
+      SET RETTmp = "+name_cut(econ_choice)+"RETTemp1#{bias_sensor}_#{$faulttype}, !- <none>
+      SET RETHumRat = "+name_cut(econ_choice)+"RETOmega1#{bias_sensor}_#{$faulttype}, !- <none>
+      SET OATmp = "+name_cut(econ_choice)+"OATTemp1#{bias_sensor}_#{$faulttype}, !- <none>
+      SET OAHumRat = "+name_cut(econ_choice)+"OATOmega1#{bias_sensor}_#{$faulttype}, !- <none>
+      SET PTmp = "+name_cut(econ_choice)+"RETPressure1#{bias_sensor}_#{$faulttype}, !- <none>
       IF PTmp < DELTASMALL, !- <none>
       SET PTmp = 101325.0, !- Zero pressure during warmup may crash the code
       ENDIF, !- <none>
@@ -219,12 +219,12 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
     "
   end
   main_body = main_body+"
-      SET VDOT_DES = DesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_RH, !- <none>
-      SET CMDOT_D = CMDesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_RH, !- <none>
-      SET HMDOT_D = HMDesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_RH, !- <none>
+      SET VDOT_DES = DesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype}, !- <none>
+      SET CMDOT_D = CMDesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype}, !- <none>
+      SET HMDOT_D = HMDesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype}, !- <none>
       SET MDOT_DES = @Max CMDOT_D HMDOT_D, !- <none>
-      SET MDOT_OA_MIN = MinOAMdot"+name_cut(econ_choice)+"#{bias_sensor}_RH, !- <none>
-      SET MDOT_OA_MAX = MaxOAMdot"+name_cut(econ_choice)+"#{bias_sensor}_RH, !- <none>
+      SET MDOT_OA_MIN = MinOAMdot"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype}, !- <none>
+      SET MDOT_OA_MAX = MaxOAMdot"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype}, !- <none>
       IF VDOT_DES > SMALLVOLFLOW, !- <none>
       SET MIN_FRAC = MDOT_OA_MIN/MDOT_DES, !- no if statement for airloop existence because the code won't work without an airloop
       SET MIN_FLOW = MDOT_OA_MIN, !- <none>
@@ -236,7 +236,7 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
   
   if not controlleroutdoorair.getString(16).to_s.eql?("")  #Minimum Outdoor Air Schedule Name
     main_body = main_body+"
-      SET MIN_SCH_VALUE = "+name_cut(econ_choice)+"_MIN_SCH#{bias_sensor}_RH, !- <none>
+      SET MIN_SCH_VALUE = "+name_cut(econ_choice)+"_MIN_SCH#{bias_sensor}_#{$faulttype}, !- <none>
       SET MIN_SCH_VALUE = @MAX MIN_SCH_VALUE 0.00, !- <none>
       SET MIN_SCH_VALUE = @MIN MIN_SCH_VALUE 1.00, !- <none>
       SET MIN_FRAC = MIN_SCH_VALUE*MIN_FRAC, !- <none>
@@ -267,7 +267,7 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
               zone_name = name_cut(controllermechventilation.getString(4+3*i+1).to_s)
               if outdoorairspec.numFields == 7  #multiply the number with a schedule
                 main_body = main_body+"
-                  SET MECH_SCH = "+zone_name+"_OA_SCH#{bias_sensor}_RH, !- NEED A SENSOR FOR THE SCHEDULE
+                  SET MECH_SCH = "+zone_name+"_OA_SCH#{bias_sensor}_#{$faulttype}, !- NEED A SENSOR FOR THE SCHEDULE
                 "
               else
                 main_body = main_body+"
@@ -276,10 +276,10 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
               end
               if outdoorairspec.getString(1).to_s.eql?("Sum") #add code for summation
                 main_body = main_body+"
-                  SET ZONE_VOL = "+zone_name+"_VOL#{bias_sensor}_RH, !- NEED INTERNAL VARIABLE FOR ZONE VOLUME
-                  SET ZONE_MUL = "+zone_name+"_MUL#{bias_sensor}_RH, !- NEED INTERNAL VARIABLE FOR ZONE MULTIPLIER
-                  SET ZONE_LIST_MUL = "+zone_name+"_LIST_MUL#{bias_sensor}_RH, !- NEED INTERNAL VARIABLE FOR ZONE LIST MULTIPLIER
-				"  
+                  SET ZONE_VOL = "+zone_name+"_VOL#{bias_sensor}_#{$faulttype}, !- NEED INTERNAL VARIABLE FOR ZONE VOLUME
+                  SET ZONE_MUL = "+zone_name+"_MUL#{bias_sensor}_#{$faulttype}, !- NEED INTERNAL VARIABLE FOR ZONE MULTIPLIER
+                  SET ZONE_LIST_MUL = "+zone_name+"_LIST_MUL#{bias_sensor}_#{$faulttype}, !- NEED INTERNAL VARIABLE FOR ZONE LIST MULTIPLIER
+				"
 				#####################################################
 				if peoples.empty?
 				  main_body = main_body+"
@@ -299,11 +299,11 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
 				  end
 			    end
 				#####################################################
-				main_body = main_body+"  
+				main_body = main_body+"
                   SET IND_OA = #{outdoorairspec.getString(2).to_s}, !- Zone occupant flow rate
                   SET IND_OA = IND_OA*ZONE_MUL*ZONE_LIST_MUL*ZONE_PPL, !- <none>
                   SET OA_MECH = OA_MECH+IND_OA*MECH_SCH, !- <none>
-                  SET ZONE_AREA = "+zone_name+"_AREA#{bias_sensor}_RH, !- NEED INTERNAL VARIABLE FOR ZONE FLOOR AREA
+                  SET ZONE_AREA = "+zone_name+"_AREA#{bias_sensor}_#{$faulttype}, !- NEED INTERNAL VARIABLE FOR ZONE FLOOR AREA
                   SET IND_OA = "+outdoorairspec.getString(3).to_s+"*ZONE_AREA, !- Zone floor area flow rate
                   SET IND_OA = IND_OA*ZONE_MUL*ZONE_LIST_MUL, !- <none>
                   SET OA_MECH = OA_MECH+IND_OA*MECH_SCH, !- <none>
@@ -317,14 +317,14 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
               else #add code for maximum
                 main_body = main_body+"
                   SET IND_OA_FIN = 0.0, !- For maximum calculation
-                  SET ZONE_VOL = "+zone_name+"_VOL#{bias_sensor}_RH, !- NEED INTERNAL VARIABLE FOR ZONE VOLUME
-                  SET ZONE_MUL = "+zone_name+"_MUL#{bias_sensor}_RH, !- NEED INTERNAL VARIABLE FOR ZONE MULTIPLIER
-                  SET ZONE_LIST_MUL = "+zone_name+"_LIST_MUL#{bias_sensor}_RH, !- NEED INTERNAL VARIABLE FOR ZONE LIST MULTIPLIER
-                  SET ZONE_PPL = "+zone_name+"_PEOPLE#{bias_sensor}_RH, !- NEED SENSOR FOR ZONE People Occupant Count
+                  SET ZONE_VOL = "+zone_name+"_VOL#{bias_sensor}_#{$faulttype}, !- NEED INTERNAL VARIABLE FOR ZONE VOLUME
+                  SET ZONE_MUL = "+zone_name+"_MUL#{bias_sensor}_#{$faulttype}, !- NEED INTERNAL VARIABLE FOR ZONE MULTIPLIER
+                  SET ZONE_LIST_MUL = "+zone_name+"_LIST_MUL#{bias_sensor}_#{$faulttype}, !- NEED INTERNAL VARIABLE FOR ZONE LIST MULTIPLIER
+                  SET ZONE_PPL = "+zone_name+"_PEOPLE#{bias_sensor}_#{$faulttype}, !- NEED SENSOR FOR ZONE People Occupant Count
                   SET IND_OA = #{outdoorairspec.getString(2).to_s}, !- Zone occupant flow rate
                   SET IND_OA = IND_OA*ZONE_MUL*ZONE_LIST_MUL*ZONE_PPL, !- <none>
                   SET IND_OA_FIN = @Max IND_OA_FIN IND_OA, !- <none>
-                  SET ZONE_AREA = "+zone_name+"_AREA#{bias_sensor}_RH, !- NEED INTERNAL VARIABLE FOR ZONE FLOOR AREA
+                  SET ZONE_AREA = "+zone_name+"_AREA#{bias_sensor}_#{$faulttype}, !- NEED INTERNAL VARIABLE FOR ZONE FLOOR AREA
                   SET IND_OA = "+outdoorairspec.getString(3).to_s+"*ZONE_AREA, !- Zone floor area flow rate
                   SET IND_OA = IND_OA*ZONE_MUL*ZONE_LIST_MUL, !- <none>
                   SET IND_OA_FIN = @Max IND_OA_FIN IND_OA, !- <none>
@@ -358,15 +358,15 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
     SET TDiff = RETTmp-OATmp, !- <none>
     SET TDiff = @Abs TDiff, !- <none>
     IF TDiff > DELTASMALL, !- <none>
-    SET OA_SIGN = (RETTmp-"+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_RH)/(RETTmp-OATmp), !- Initialize the signal
+    SET OA_SIGN = (RETTmp-"+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype})/(RETTmp-OATmp), !- Initialize the signal
     ELSE, !- <none>
-    IF RETTmp < "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_RH && RETTmp >= OATmp, !- <none>
+    IF RETTmp < "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype} && RETTmp >= OATmp, !- <none>
     SET OA_SIGN = -1, !- <none>
-    ELSEIF RETTmp < "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_RH && RETTmp < OATmp, !- <none>
+    ELSEIF RETTmp < "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype} && RETTmp < OATmp, !- <none>
     SET OA_SIGN = 1, !- <none>
-    ELSEIF RETTmp >= "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_RH && RETTmp >= OATmp,
+    ELSEIF RETTmp >= "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype} && RETTmp >= OATmp,
     SET OA_SIGN = 1, !- <none>
-    ELSEIF RETTmp >= "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_RH && RETTmp < OATmp,
+    ELSEIF RETTmp >= "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype} && RETTmp < OATmp,
     SET OA_SIGN = -1, !- <none>
     ENDIF, !- <none>
     ENDIF, !- <none>
@@ -406,7 +406,7 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
                   if branch.getString(ii).to_s.eql?(oas_name)
                     airsystem_name = branch.getString(0).to_s.gsub(" Supply Branch","").gsub(" Main Branch","")
                     main_body = main_body+"
-                      SET LOCKOUT_POS = "+name_cut(airsystem_name)+"_Htg#{bias_sensor}_RH, !- <none>
+                      SET LOCKOUT_POS = "+name_cut(airsystem_name)+"_Htg#{bias_sensor}_#{$faulttype}, !- <none>
                       IF LOCKOUT_POS > 0, !- <none>
                       SET NO_LOCK_OUT = False, !- <none>
                       ENDIF, !- <none>
@@ -415,7 +415,7 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
                       #check if there is a compressor on the loop
                       #if there is, add code to check if the economizer should be locked out
                       main_body = main_body+"
-                        SET LOCKOUT_POS = "+name_cut(airsystem_name)+"_Ctg#{bias_sensor}_RH, !- <none>
+                        SET LOCKOUT_POS = "+name_cut(airsystem_name)+"_Ctg#{bias_sensor}_#{$faulttype}, !- <none>
                         IF LOCKOUT_POS > 0, !- <none>
                         SET NO_LOCK_OUT = False, !- <none>
                         ENDIF, !- <none>
@@ -441,7 +441,7 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
       SET HIGHHUMCTRL = False, !- <none>
       ELSE, !- Running the economizer
       SET ECON_OP = True, !- <none>
-      IF OATmp > "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_RH, !- <none>
+      IF OATmp > "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype}, !- <none>
       SET OA_SIGN = 1, !- <none>
       ENDIF, !- <none>
     "
@@ -492,13 +492,13 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
     end
     if controlleroutdoorair.getString(21).to_s.eql?("Yes")  #High humidity control check
       main_body = main_body+"
-        IF ZoneHumidLOAD"+name_cut(econ_choice)+"#{bias_sensor}_RH < 0.0, !- High Humidity Control
+        IF ZoneHumidLOAD"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype} < 0.0, !- High Humidity Control
         SET HIGHHUMCTRL = True, !- <none>
         ENDIF, !- <none>
       "
       if controlleroutdoorair.getString(24).to_s.eql?("Yes")  #Control High Indoor Humidity Based on Outdoor Humidity Ratio
         main_body = main_body+"
-          IF ZoneHumid"+name_cut(econ_choice)+"#{bias_sensor}_RH <= OAHumRat, !- Control High Indoor Humidity Based on Outdoor Humidity Ratio
+          IF ZoneHumid"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype} <= OAHumRat, !- Control High Indoor Humidity Based on Outdoor Humidity Ratio
           SET HIGHHUMCTRL = False, !- Set it back to False
           ENDIF, !- <none>
         "
@@ -506,7 +506,7 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
     end
     if not controlleroutdoorair.getString(20).to_s.eql?("")  #Time of Day Economizer Control Schedule Name
       main_body = main_body+"
-        SET ECON_FLOW_SCH_VAL = ECONCTRL"+name_cut(econ_choice)+"_SCH#{bias_sensor}_RH, !- <none>
+        SET ECON_FLOW_SCH_VAL = ECONCTRL"+name_cut(econ_choice)+"_SCH#{bias_sensor}_#{$faulttype}, !- <none>
         IF ECON_FLOW_SCH_VAL > 0, !- <none>
         SET OA_SIGN = 1.0, !- <none>
         SET ECON_OP = True, !- <none>
@@ -536,17 +536,17 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
     IF NIGHTVENT == 0,
     IF OA_SIGN > MIN_FRAC,
     IF OA_SIGN < 1.0,
-    IF MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_RH > SMALLMASSFLOW, !- Check if the duct has airflow
-    SET RETENTH_GB#{econ_short_name}#{bias_sensor}_RH = ORI_RETENTH, !- to simulate feedback control, don't use measurement values
-    SET RETHUMRAT_GB#{econ_short_name}#{bias_sensor}_RH = ORI_RETHumRat, !- to simulate feedback control, don't use measurement values
-    SET OAENTH_GB#{econ_short_name}#{bias_sensor}_RH = ORI_OAENTH, !- to simulate feedback control, don't use measurement values
-    SET OAHUMRAT_GB#{econ_short_name}#{bias_sensor}_RH = ORI_OAHumRat, !- to simulate feedback control, don't use measurement values
-    SET LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_RH = MIN_FRAC, !- <none>
-    SET UPLIMIT_GB#{econ_short_name}#{bias_sensor}_RH = 1, !- <none>
-    SET MIXTEMPSET_GB#{econ_short_name}#{bias_sensor}_RH = "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_RH, !-<none>
-    RUN EMSSolveRegulaFalsi_OA_SIGN#{econ_short_name}#{bias_sensor}_RH, !- <none>
-    IF FLAG_GB#{econ_short_name}#{bias_sensor}_RH > 0, !- <none>
-    SET OA_SIGN = SOLN_GB#{econ_short_name}#{bias_sensor}_RH, !- <none>
+    IF MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} > SMALLMASSFLOW, !- Check if the duct has airflow
+    SET RETENTH_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = ORI_RETENTH, !- to simulate feedback control, don't use measurement values
+    SET RETHUMRAT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = ORI_RETHumRat, !- to simulate feedback control, don't use measurement values
+    SET OAENTH_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = ORI_OAENTH, !- to simulate feedback control, don't use measurement values
+    SET OAHUMRAT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = ORI_OAHumRat, !- to simulate feedback control, don't use measurement values
+    SET LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = MIN_FRAC, !- <none>
+    SET UPLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = 1, !- <none>
+    SET MIXTEMPSET_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype}, !-<none>
+    RUN EMSSolveRegulaFalsi_OA_SIGN#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+    IF FLAG_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} > 0, !- <none>
+    SET OA_SIGN = SOLN_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
     ENDIF,
     ENDIF,
     ENDIF,
@@ -566,10 +566,10 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
   if controlleroutdoorair.getString(21).to_s.eql?("Yes")  #High humidity control check
     main_body = main_body+"
       IF HIGHHUMCTRL == True, !- high humidity control
-      SET MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_RH = "+name_cut(econ_choice)+"MixAirFlow_CTRL#{bias_sensor}_RH, !- <none>
+      SET MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = "+name_cut(econ_choice)+"MixAirFlow_CTRL#{bias_sensor}_#{$faulttype}, !- <none>
       SET OA_SIGN_CAN = "+controlleroutdoorair.getString(23).to_s+", !- <none>
       SET OA_SIGN_CAN = OA_SIGN_CAN*MDOT_OA_MAX, !- <none>
-      SET OA_SIGN_CAN = OA_SIGN_CAN/MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_RH, !- <none>
+      SET OA_SIGN_CAN = OA_SIGN_CAN/MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
       SET OA_SIGN = @MAX OA_SIGN_CAN MIN_FRAC, !- <none>
       ENDIF,
     "
@@ -592,12 +592,12 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
   
   if not controlleroutdoorair.getString(17).to_s.eql?("")  #Minimum Fraction of Outdoor Air Schedule Name
     main_body = main_body+"
-      SET MIN_SCH_VALUE = "+name_cut(econ_choice)+"_MIN_FRAC_SCH#{bias_sensor}_RH, !- <none>
+      SET MIN_SCH_VALUE = "+name_cut(econ_choice)+"_MIN_FRAC_SCH#{bias_sensor}_#{$faulttype}, !- <none>
       SET MIN_SCH_VALUE = @Max MIN_SCH_VALUE 0.0, !- <none>
       SET MIN_SCH_VALUE = @Min MIN_SCH_VALUE 1.0, !- <none>
       IF MIN_SCH_VALUE > MIN_FRAC, !- <none>
       SET MIN_FRAC = MIN_SCH_VALUE, !- <none>
-      SET MDOT_OA_MIN = MIN_FRAC*MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_RH, !- <none>
+      SET MDOT_OA_MIN = MIN_FRAC*MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
       ENDIF, !- <none>
       SET OA_SIGN = @Max OA_SIGN MIN_FRAC, !- <none>
     "
@@ -605,12 +605,12 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
   
   if not controlleroutdoorair.getString(18).to_s.eql?("")  #Maximum Fraction of Outdoor Air Schedule Name
     main_body = main_body+"
-      SET MAX_SCH_VALUE = "+name_cut(econ_choice)+"_MAX_FRAC_SCH#{bias_sensor}_RH, !- <none>
+      SET MAX_SCH_VALUE = "+name_cut(econ_choice)+"_MAX_FRAC_SCH#{bias_sensor}_#{$faulttype}, !- <none>
       SET MAX_SCH_VALUE = @Max MAX_SCH_VALUE 0.0, !- <none>
       SET MAX_SCH_VALUE = @Min MAX_SCH_VALUE 1.0, !- <none>
       IF MIN_FRAC > MAX_SCH_VALUE, !- <none>
       SET MIN_FRAC = MAX_SCH_VALUE, !- <none>
-      SET MDOT_OA_MIN = MIN_FRAC*MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_RH, !- <none>
+      SET MDOT_OA_MIN = MIN_FRAC*MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
       ENDIF, !- <none>
       SET OA_SIGN = @Min OA_SIGN MAX_SCH_VALUE, !- <none>
     "
@@ -618,14 +618,14 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
   
   #calculate the outdoor airflow rate
   main_body = main_body+"
-    SET FinalFlow = OA_SIGN*MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_RH, !- <none>
+    SET FinalFlow = OA_SIGN*MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
   "
   
   #make sure that it doesn't exceed the limits of ventilation
   if not controlleroutdoorair.getString(19).to_s.eql?("")
     main_body = main_body+"
       IF OA_MECH > FinalFlow, !- <none>
-      SET FinalFlow = @Min OA_MECH MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_RH, !- <none>
+      SET FinalFlow = @Min OA_MECH MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
       ENDIF, !- <none>
     "
   end
@@ -636,7 +636,7 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
   if controlleroutdoorair.getString(15).to_s.eql?("FixedMinimum")
     main_body = main_body+"
       SET OA_NEW = FinalFlow, !- <none>
-      SET DUMMY = MinOAMdot"+name_cut(econ_choice)+"#{bias_sensor}_RH, !- Name too long
+      SET DUMMY = MinOAMdot"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype}, !- Name too long
       SET OA_NEW = @Max OA_NEW (DUMMY*MIN_SCH_VALUE), !- <none>
       SET FinalFlow = OA_NEW, !- <none>
     "
@@ -645,7 +645,7 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
   #check with mixed airflow
   main_body = main_body+"
     SET OA_NEW = FinalFlow, !- <none>
-    SET OA_NEW = @Min OA_NEW MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_RH, !- <none>
+    SET OA_NEW = @Min OA_NEW MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
     SET FinalFlow = OA_NEW, !- <none>
   "
   
@@ -661,7 +661,7 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
     SET OA_NEW = @Min MDOT_OA_MAX OA_NEW, !- <none>
     SET FinalFlow = OA_NEW, !- <none>
     ENDIF, !- <none>
-    SET "+name_cut(econ_choice)+"MDOT_OA#{bias_sensor}_RH = FinalFlow; !- <none>
+    SET "+name_cut(econ_choice)+"MDOT_OA#{bias_sensor}_#{$faulttype} = FinalFlow; !- <none>
   "
   
   return main_body
@@ -782,17 +782,17 @@ def econ_rh_sensor_bias_ems_other(string_objects, workspace, bias_sensor, contro
   
   string_objects << "
     EnergyManagementSystem:Subroutine,
-      RES_OA_SIGN#{econ_short_name}#{bias_sensor}_RH, !- Name
-      SET TEMP_OA_SIGN = OA_SIGN_GB#{econ_short_name}#{bias_sensor}_RH, !- <none>
-      SET TEMP_MIX_FLOW = MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_RH, !- <none>
+      RES_OA_SIGN#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- Name
+      SET TEMP_OA_SIGN = OA_SIGN_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      SET TEMP_MIX_FLOW = MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
       SET TEMP_OA_FLOW = TEMP_OA_SIGN*TEMP_MIX_FLOW, !- <none>
       SET RECFLOW1 = 0, !- <none>
       SET RECFLOW2 = TEMP_MIX_FLOW-TEMP_OA_FLOW, !- <none>
       SET RECIR_FLOW = @MAX RECFLOW1 RECFLOW2, !- <none>
-      SET TEMP_RETENTH = RETENTH_GB#{econ_short_name}#{bias_sensor}_RH, !- <none>
-      SET TEMP_RETHUMRAT = RETHUMRAT_GB#{econ_short_name}#{bias_sensor}_RH, !- <none>
-      SET TEMP_OAENTH = OAENTH_GB#{econ_short_name}#{bias_sensor}_RH, !- <none>
-      SET TEMP_OAHUMRAT = OAHUMRAT_GB#{econ_short_name}#{bias_sensor}_RH, !- <none>
+      SET TEMP_RETENTH = RETENTH_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      SET TEMP_RETHUMRAT = RETHUMRAT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      SET TEMP_OAENTH = OAENTH_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      SET TEMP_OAHUMRAT = OAHUMRAT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
       SET TEMP_MIXENTH = RECIR_FLOW*TEMP_RETENTH, !- <none>
       SET TEMP_MIXENTH = TEMP_MIXENTH+TEMP_OA_FLOW*TEMP_OAENTH, !- <none>
       SET TEMP_MIXENTH = TEMP_MIXENTH/TEMP_MIX_FLOW, !- <none>
@@ -800,23 +800,23 @@ def econ_rh_sensor_bias_ems_other(string_objects, workspace, bias_sensor, contro
       SET TEMP_MIXHUMRAT = TEMP_MIXHUMRAT+TEMP_OA_FLOW*TEMP_OAHUMRAT, !- <none>
       SET TEMP_MIXHUMRAT = TEMP_MIXHUMRAT/TEMP_MIX_FLOW, !- <none>
       SET TEMP_MIXTEMP = @TdbFnHW TEMP_MIXENTH TEMP_MIXHUMRAT, !- <none>
-      SET TEMP_AA = MIXTEMPSET_GB#{econ_short_name}#{bias_sensor}_RH-TEMP_MIXTEMP, !- <none>
-      SET RESIDUAL_GB#{econ_short_name}#{bias_sensor}_RH = TEMP_AA; !- <none>
+      SET TEMP_AA = MIXTEMPSET_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}-TEMP_MIXTEMP, !- <none>
+      SET RESIDUAL_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = TEMP_AA; !- <none>
   "
   
   string_objects << "
     EnergyManagementSystem:Subroutine,
-      EMSSolveRegulaFalsi_OA_SIGN#{econ_short_name}#{bias_sensor}_RH, !- Name
-      SET OA_SIGN_GB#{econ_short_name}#{bias_sensor}_RH = LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_RH, !- <none>
-      RUN RES_OA_SIGN#{econ_short_name}#{bias_sensor}_RH, !- <none>
-      SET Y0 = RESIDUAL_GB#{econ_short_name}#{bias_sensor}_RH, !- <none>
-      SET OA_SIGN_GB#{econ_short_name}#{bias_sensor}_RH = UPLIMIT_GB#{econ_short_name}#{bias_sensor}_RH, !- <none>
-      RUN RES_OA_SIGN#{econ_short_name}#{bias_sensor}_RH, !- <none>
-      SET Y1 = RESIDUAL_GB#{econ_short_name}#{bias_sensor}_RH, !- <none>
+      EMSSolveRegulaFalsi_OA_SIGN#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- Name
+      SET OA_SIGN_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      RUN RES_OA_SIGN#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      SET Y0 = RESIDUAL_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      SET OA_SIGN_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = UPLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      RUN RES_OA_SIGN#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      SET Y1 = RESIDUAL_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
       SET PROD = Y0*Y1, !- <none>
       IF Y0*Y1 > 0, !- <none>
-      SET FLAG_GB#{econ_short_name}#{bias_sensor}_RH = -2, !- <none>
-      SET SOLN_GB#{econ_short_name}#{bias_sensor}_RH = LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_RH, !- <none>
+      SET FLAG_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = -2, !- <none>
+      SET SOLN_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
       RETURN, ! Error for solution
       ENDIF, !- <none>
       SET CONT = 1, !- <none>
@@ -830,11 +830,11 @@ def econ_rh_sensor_bias_ems_other(string_objects, workspace, bias_sensor, contro
       SET DY = 1.d-10, !- <none>
       ENDIF, !- <none>
       ENDIF, !- <none>
-      SET XTemp = Y0*UPLIMIT_GB#{econ_short_name}#{bias_sensor}_RH, !- <none>
-      SET XTemp = (XTemp-Y1*LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_RH)/DY, !- <none>
-      SET OA_SIGN_GB#{econ_short_name}#{bias_sensor}_RH = XTemp, !- <none>
-      RUN RES_OA_SIGN#{econ_short_name}#{bias_sensor}_RH, !- <none>
-      SET YTemp = RESIDUAL_GB#{econ_short_name}#{bias_sensor}_RH, !- <none>
+      SET XTemp = Y0*UPLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      SET XTemp = (XTemp-Y1*LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype})/DY, !- <none>
+      SET OA_SIGN_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = XTemp, !- <none>
+      RUN RES_OA_SIGN#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      SET YTemp = RESIDUAL_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
       SET NITE = NITE+1, !- <none>
       IF YTemp < 0.0001 && YTemp+0.0001 > 0, !- <none>
       SET CONT = 0, !- <none>
@@ -845,101 +845,101 @@ def econ_rh_sensor_bias_ems_other(string_objects, workspace, bias_sensor, contro
       IF CONT > 0.0d0, !- <none>
       IF Y0 < 0.0d0, !- <none>
       IF YTemp < 0.0d0, !- <none>
-      SET LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_RH = XTemp, !- <none>
+      SET LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = XTemp, !- <none>
       SET Y0 = YTemp, !- <none>
       ELSE, !- <none>
-      SET UPLIMIT_GB#{econ_short_name}#{bias_sensor}_RH = XTemp, !- <none>
+      SET UPLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = XTemp, !- <none>
       SET Y1 = YTemp, !- <none>
       ENDIF, !- <none>
       ELSE, !- <none>
       IF YTemp < 0.0d0, !- <none>
-      SET UPLIMIT_GB#{econ_short_name}#{bias_sensor}_RH = XTemp, !- <none>
+      SET UPLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = XTemp, !- <none>
       SET Y1 = YTemp, !- <none>
       ELSE, !- <none>
-      SET LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_RH = XTemp, !- <none>
+      SET LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = XTemp, !- <none>
       SET Y0 = YTemp, !- <none>
       ENDIF, !- <none>
       ENDIF, !- <none>
       ENDIF, !- <none>
       ENDWHILE, !- <none>
       IF CONV == 1, !- <none>
-      SET FLAG_GB#{econ_short_name}#{bias_sensor}_RH = NITE, !- <none>
+      SET FLAG_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = NITE, !- <none>
       ELSE,
-      SET FLAG_GB#{econ_short_name}#{bias_sensor}_RH = -1, !- <none>
+      SET FLAG_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = -1, !- <none>
       ENDIF, !- <none>
-      SET SOLN_GB#{econ_short_name}#{bias_sensor}_RH = XTemp; !- <none>
+      SET SOLN_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = XTemp; !- <none>
   "
   
   string_objects << "
     EnergyManagementSystem:ProgramCallingManager,
       EMSCallRH_BIAS"+name_cut(econ_choice)+", !- Name
       InsideHVACSystemIterationLoop,       !- EnergyPlus Model Calling Point
-      RH_BIAS"+name_cut(econ_choice)+"#{bias_sensor}_RH, !- Name
+      RH_BIAS"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype}, !- Name
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      RESIDUAL_GB#{econ_short_name}#{bias_sensor}_RH;
+      RESIDUAL_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_RH;
+      LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      UPLIMIT_GB#{econ_short_name}#{bias_sensor}_RH;
+      UPLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      FLAG_GB#{econ_short_name}#{bias_sensor}_RH;
+      FLAG_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      SOLN_GB#{econ_short_name}#{bias_sensor}_RH;
+      SOLN_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      OA_SIGN_GB#{econ_short_name}#{bias_sensor}_RH;
+      OA_SIGN_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_RH;
+      MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      RETENTH_GB#{econ_short_name}#{bias_sensor}_RH;
+      RETENTH_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      RETHUMRAT_GB#{econ_short_name}#{bias_sensor}_RH;
+      RETHUMRAT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      OAENTH_GB#{econ_short_name}#{bias_sensor}_RH;
+      OAENTH_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      OAHUMRAT_GB#{econ_short_name}#{bias_sensor}_RH;
+      OAHUMRAT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      MIXTEMPSET_GB#{econ_short_name}#{bias_sensor}_RH;
+      MIXTEMPSET_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "   
     EnergyManagementSystem:Actuator,
-      "+name_cut(econ_choice)+"MDOT_OA#{bias_sensor}_RH,        !- Name
+      "+name_cut(econ_choice)+"MDOT_OA#{bias_sensor}_#{$faulttype},        !- Name
       "+econ_choice+", !- Actuated Component Unique Name
       Outdoor Air Controller,                                  !- Actuated Component Type
       Air Mass Flow Rate;                           !- Actuated Component Control Type
@@ -976,35 +976,35 @@ def econ_rh_sensor_bias_ems_other(string_objects, workspace, bias_sensor, contro
   
   string_objects << "
     EnergyManagementSystem:InternalVariable,
-      DesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_RH,
+      DesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype},
       "+airsystem_name+",
       Intermediate Air System Main Supply Volume Flow Rate;
   "
   
   string_objects << "
     EnergyManagementSystem:InternalVariable,
-      CMDesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_RH,
+      CMDesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype},
       "+airsystem_name+",
       Intermediate Air System "+sizing_option+" Peak Cooling Mass Flow Rate;
   "
   
   string_objects << "
     EnergyManagementSystem:InternalVariable,
-      HMDesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_RH,
+      HMDesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype},
       "+airsystem_name+",
       Intermediate Air System "+sizing_option+" Peak Heating Mass Flow Rate;
   "
   
   string_objects << "
     EnergyManagementSystem:InternalVariable,
-      MinOAMdot"+name_cut(econ_choice)+"#{bias_sensor}_RH,
+      MinOAMdot"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype},
       "+econ_choice+",
       Outdoor Air Controller Minimum Mass Flow Rate;
   "
   
   string_objects << "
     EnergyManagementSystem:InternalVariable,
-      MaxOAMdot"+name_cut(econ_choice)+"#{bias_sensor}_RH,
+      MaxOAMdot"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype},
       "+econ_choice+",
       Outdoor Air Controller Maximum Mass Flow Rate;
   "
@@ -1032,25 +1032,25 @@ def econ_rh_sensor_bias_ems_other(string_objects, workspace, bias_sensor, contro
               zone_name_tag = name_cut(zone_name)
               string_objects << "
                 EnergyManagementSystem:InternalVariable,
-                  "+zone_name_tag+"_VOL#{bias_sensor}_RH,
+                  "+zone_name_tag+"_VOL#{bias_sensor}_#{$faulttype},
                   "+zone_name+",
                   Zone Air Volume;
               "
               string_objects << "
                 EnergyManagementSystem:InternalVariable,
-                  "+zone_name_tag+"_MUL#{bias_sensor}_RH,
+                  "+zone_name_tag+"_MUL#{bias_sensor}_#{$faulttype},
                   "+zone_name+",
                   Zone Multiplier;
               "
               string_objects << "
                 EnergyManagementSystem:InternalVariable,
-                  "+zone_name_tag+"_LIST_MUL#{bias_sensor}_RH,
+                  "+zone_name_tag+"_LIST_MUL#{bias_sensor}_#{$faulttype},
                   "+zone_name+",
                   Zone List Multiplier;
               "
               string_objects << "
                 EnergyManagementSystem:InternalVariable,
-                  "+zone_name_tag+"_AREA#{bias_sensor}_RH,
+                  "+zone_name_tag+"_AREA#{bias_sensor}_#{$faulttype},
                   "+zone_name+",
                   Zone Floor Area;
               "
@@ -1069,7 +1069,7 @@ def econ_rh_sensor_bias_ems_other(string_objects, workspace, bias_sensor, contro
 			  #####################################################
               string_objects << "
                 EnergyManagementSystem:Sensor,
-                  "+zone_name_tag+"_OA_SCH#{bias_sensor}_RH, !- Name
+                  "+zone_name_tag+"_OA_SCH#{bias_sensor}_#{$faulttype}, !- Name
                   "+oaschedule_name+",                        !- Output:Variable or Output:Meter Index Key Name
                   Schedule Value;                !- Output:Variable or Output:Meter Name
               "
@@ -1082,14 +1082,14 @@ def econ_rh_sensor_bias_ems_other(string_objects, workspace, bias_sensor, contro
   
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(airsystem_name)+"_Htg#{bias_sensor}_RH,
+      "+name_cut(airsystem_name)+"_Htg#{bias_sensor}_#{$faulttype},
       "+airsystem_name+",
       Air System Heating Coil Total Heating Energy;
   "
   
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(airsystem_name)+"_Ctg#{bias_sensor}_RH,
+      "+name_cut(airsystem_name)+"_Ctg#{bias_sensor}_#{$faulttype},
       "+airsystem_name+",
       Air System Cooling Coil Total Cooling Energy;
   "
@@ -1097,21 +1097,21 @@ def econ_rh_sensor_bias_ems_other(string_objects, workspace, bias_sensor, contro
   ret_node_name = controlleroutdoorair.getString(2).to_s
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(econ_choice)+"RETTemp1#{bias_sensor}_RH,  !- Name
+      "+name_cut(econ_choice)+"RETTemp1#{bias_sensor}_#{$faulttype},  !- Name
       "+ret_node_name+",                        !- Output:Variable or Output:Meter Index Key Name
       System Node Temperature;                !- Output:Variable or Output:Meter Name
   "
   
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(econ_choice)+"RETOmega1#{bias_sensor}_RH,  !- Name
+      "+name_cut(econ_choice)+"RETOmega1#{bias_sensor}_#{$faulttype},  !- Name
       "+ret_node_name+",                        !- Output:Variable or Output:Meter Index Key Name
       System Node Humidity Ratio;                !- Output:Variable or Output:Meter Name
   "
   
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(econ_choice)+"RETPressure1#{bias_sensor}_RH,  !- Name
+      "+name_cut(econ_choice)+"RETPressure1#{bias_sensor}_#{$faulttype},  !- Name
       "+ret_node_name+",                        !- Output:Variable or Output:Meter Index Key Name
       System Node Pressure;                !- Output:Variable or Output:Meter Name
   "
@@ -1119,7 +1119,7 @@ def econ_rh_sensor_bias_ems_other(string_objects, workspace, bias_sensor, contro
   mx_node_name = controlleroutdoorair.getString(3).to_s
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_RH,  !- Name
+      "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype},  !- Name
       "+mx_node_name+",                        !- Output:Variable or Output:Meter Index Key Name
       System Node Setpoint Temperature;                !- Output:Variable or Output:Meter Name
   "
@@ -1127,21 +1127,21 @@ def econ_rh_sensor_bias_ems_other(string_objects, workspace, bias_sensor, contro
   oa_node_name = controlleroutdoorair.getString(4).to_s
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(econ_choice)+"OATTemp1#{bias_sensor}_RH,  !- Name
+      "+name_cut(econ_choice)+"OATTemp1#{bias_sensor}_#{$faulttype},  !- Name
       "+oa_node_name+",                        !- Output:Variable or Output:Meter Index Key Name
       System Node Temperature;                !- Output:Variable or Output:Meter Name
   "
   
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(econ_choice)+"OATOmega1#{bias_sensor}_RH,  !- Name
+      "+name_cut(econ_choice)+"OATOmega1#{bias_sensor}_#{$faulttype},  !- Name
       "+oa_node_name+",                        !- Output:Variable or Output:Meter Index Key Name
       System Node Humidity Ratio;                !- Output:Variable or Output:Meter Name
   "
   
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(econ_choice)+"MixAirFlow_CTRL#{bias_sensor}_RH,  !- Name
+      "+name_cut(econ_choice)+"MixAirFlow_CTRL#{bias_sensor}_#{$faulttype},  !- Name
       "+airsystem_name+",                        !- Output:Variable or Output:Meter Index Key Name
       Air System Mixed Air Mass Flow Rate;                !- Output:Variable or Output:Meter Name
   "
@@ -1152,7 +1152,7 @@ def econ_rh_sensor_bias_ems_other(string_objects, workspace, bias_sensor, contro
     # check high humidity control before adding
     string_objects << "
       EnergyManagementSystem:Sensor,
-        ZoneHumid"+name_cut(econ_choice)+"#{bias_sensor}_RH,  !- Name
+        ZoneHumid"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype},  !- Name
         "+humidistat_zone+",                        !- Output:Variable or Output:Meter Index Key Name
         Zone Air Humidity Ratio;                !- Output:Variable or Output:Meter Name
     "
@@ -1160,7 +1160,7 @@ def econ_rh_sensor_bias_ems_other(string_objects, workspace, bias_sensor, contro
     # check high humidity control before adding
     string_objects << "
       EnergyManagementSystem:Sensor,
-        ZoneHumidLOAD"+name_cut(econ_choice)+"#{bias_sensor}_RH,  !- Name
+        ZoneHumidLOAD"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype},  !- Name
         "+humidistat_zone+",                        !- Output:Variable or Output:Meter Index Key Name
         Zone Predicted Moisture Load to Humidifying Setpoint Moisture Transfer Rate;                !- Output:Variable or Output:Meter Name
     "
@@ -1170,7 +1170,7 @@ def econ_rh_sensor_bias_ems_other(string_objects, workspace, bias_sensor, contro
   if not controlleroutdoorair.getString(20).to_s.eql?("")
     string_objects << "
       EnergyManagementSystem:Sensor,
-        ECONCTRL"+name_cut(econ_choice)+"_SCH#{bias_sensor}_RH, !- Name
+        ECONCTRL"+name_cut(econ_choice)+"_SCH#{bias_sensor}_#{$faulttype}, !- Name
         "+controlleroutdoorair.getString(20).to_s+", !- Schedule Name
         Schedule Value; !- Output:Variable
     "
@@ -1180,7 +1180,7 @@ def econ_rh_sensor_bias_ems_other(string_objects, workspace, bias_sensor, contro
   if false
     string_objects << "
       EnergyManagementSystem:Sensor,
-        NIGHTVENT_SCH#{bias_sensor}_RH, !- Name
+        NIGHTVENT_SCH#{bias_sensor}_#{$faulttype}, !- Name
         [Schedule name from Ruby], !- Schedule Name
         Schedule Value; !- Output:Variable
     "
@@ -1190,7 +1190,7 @@ def econ_rh_sensor_bias_ems_other(string_objects, workspace, bias_sensor, contro
   if not controlleroutdoorair.getString(18).to_s.eql?("")
     string_objects << "
       EnergyManagementSystem:Sensor,
-        "+name_cut(econ_choice)+"_MAX_FRAC_SCH#{bias_sensor}_RH, !- Name
+        "+name_cut(econ_choice)+"_MAX_FRAC_SCH#{bias_sensor}_#{$faulttype}, !- Name
         "+controlleroutdoorair.getString(18).to_s+", !- Schedule Name
         Schedule Value; !- Output:Variable
     "
@@ -1200,7 +1200,7 @@ def econ_rh_sensor_bias_ems_other(string_objects, workspace, bias_sensor, contro
   if not controlleroutdoorair.getString(16).to_s.eql?("")
     string_objects << "
       EnergyManagementSystem:Sensor,
-        "+name_cut(econ_choice)+"_MIN_SCH#{bias_sensor}_RH, !- Name
+        "+name_cut(econ_choice)+"_MIN_SCH#{bias_sensor}_#{$faulttype}, !- Name
         "+controlleroutdoorair.getString(16).to_s+", !- Schedule Name
         Schedule Value; !- Output:Variable
     "
@@ -1210,7 +1210,7 @@ def econ_rh_sensor_bias_ems_other(string_objects, workspace, bias_sensor, contro
   if not controlleroutdoorair.getString(17).to_s.eql?("")
     string_objects << "
       EnergyManagementSystem:Sensor,
-        "+name_cut(econ_choice)+"_MIN_FRAC_SCH#{bias_sensor}_RH, !- Name
+        "+name_cut(econ_choice)+"_MIN_FRAC_SCH#{bias_sensor}_#{$faulttype}, !- Name
         "+controlleroutdoorair.getString(17).to_s+", !- Schedule Name
         Schedule Value; !- Output:Variable
     "

--- a/fault_measures_2017/BiasedEconomizerSensorOutdoorT/measure.rb
+++ b/fault_measures_2017/BiasedEconomizerSensorOutdoorT/measure.rb
@@ -169,7 +169,7 @@ class BiasedEconomizerSensorOAT < OpenStudio::Ruleset::WorkspaceUserScript
 		  oacontrollername = econ_choice.clone.gsub!(/[^0-9A-Za-z]/, '')
 		  ##################################################        
 		  
-          main_body = econ_t_sensor_bias_ems_main_body(runner, workspace, bias_sensor, controlleroutdoorair, [0.0, out_t_bias], oacontrollername)
+          main_body = econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorair, [0.0, out_t_bias], oacontrollername)
           
           string_objects << main_body
           

--- a/fault_measures_2017/BiasedEconomizerSensorOutdoorT/measure.rb
+++ b/fault_measures_2017/BiasedEconomizerSensorOutdoorT/measure.rb
@@ -129,10 +129,10 @@ class BiasedEconomizerSensorOAT < OpenStudio::Ruleset::WorkspaceUserScript
 	end
 	##################################################
     bias_sensor = "OA"
-    # if out_t_bias == 0
-      # runner.registerAsNotApplicable("#{name} is not running with zero fault level. Skipping......")
-      # return true
-    # end
+    if out_t_bias == 0
+      runner.registerAsNotApplicable("#{name} is not running with zero fault level. Skipping......")
+      return true
+    end
     
     runner.registerInitialCondition("Imposing Sensor Bias on #{econ_choice}.")
   

--- a/fault_measures_2017/BiasedEconomizerSensorOutdoorT/measure.rb
+++ b/fault_measures_2017/BiasedEconomizerSensorOutdoorT/measure.rb
@@ -129,10 +129,10 @@ class BiasedEconomizerSensorOAT < OpenStudio::Ruleset::WorkspaceUserScript
 	end
 	##################################################
     bias_sensor = "OA"
-    if out_t_bias == 0
-      runner.registerAsNotApplicable("#{name} is not running with zero fault level. Skipping......")
-      return true
-    end
+    # if out_t_bias == 0
+      # runner.registerAsNotApplicable("#{name} is not running with zero fault level. Skipping......")
+      # return true
+    # end
     
     runner.registerInitialCondition("Imposing Sensor Bias on #{econ_choice}.")
   

--- a/fault_measures_2017/BiasedEconomizerSensorOutdoorT/measure.xml
+++ b/fault_measures_2017/BiasedEconomizerSensorOutdoorT/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>biased_economizer_sensor_oat</name>
   <uid>75ad65c1-1f17-4fa3-be05-13a3bb415fbe</uid>
-  <version_id>74db059b-0a61-4b58-9300-2a024f8814ce</version_id>
-  <version_modified>20190415T161742Z</version_modified>
+  <version_id>f8ea38e0-9f84-42a6-bbcf-16b2c291cd11</version_id>
+  <version_modified>20190415T164118Z</version_modified>
   <xml_checksum>B7427881</xml_checksum>
   <class_name>BiasedEconomizerSensorOAT</class_name>
   <display_name>Biased Economizer Sensor: Outdoor Temperature</display_name>
@@ -117,6 +117,12 @@
       <checksum>435C6B82</checksum>
     </file>
     <file>
+      <filename>ControllerOutdoorAirFlow_T.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>E7FE2EC1</checksum>
+    </file>
+    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>1.5.0</identifier>
@@ -125,13 +131,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>F7471DDE</checksum>
-    </file>
-    <file>
-      <filename>ControllerOutdoorAirFlow_T.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>E7FE2EC1</checksum>
+      <checksum>F4420CED</checksum>
     </file>
   </files>
 </measure>

--- a/fault_measures_2017/BiasedEconomizerSensorOutdoorT/measure.xml
+++ b/fault_measures_2017/BiasedEconomizerSensorOutdoorT/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>biased_economizer_sensor_oat</name>
   <uid>75ad65c1-1f17-4fa3-be05-13a3bb415fbe</uid>
-  <version_id>c3d2e6d1-57a5-4a1c-ad40-8377bae4b275</version_id>
-  <version_modified>20190411T215033Z</version_modified>
+  <version_id>74db059b-0a61-4b58-9300-2a024f8814ce</version_id>
+  <version_modified>20190415T161742Z</version_modified>
   <xml_checksum>B7427881</xml_checksum>
   <class_name>BiasedEconomizerSensorOAT</class_name>
   <display_name>Biased Economizer Sensor: Outdoor Temperature</display_name>
@@ -125,13 +125,13 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>F4420CED</checksum>
+      <checksum>F7471DDE</checksum>
     </file>
     <file>
       <filename>ControllerOutdoorAirFlow_T.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>1A6DF28C</checksum>
+      <checksum>E7FE2EC1</checksum>
     </file>
   </files>
 </measure>

--- a/fault_measures_2017/BiasedEconomizerSensorOutdoorT/measure.xml
+++ b/fault_measures_2017/BiasedEconomizerSensorOutdoorT/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>biased_economizer_sensor_oat</name>
   <uid>75ad65c1-1f17-4fa3-be05-13a3bb415fbe</uid>
-  <version_id>2270bbf0-090c-4f9c-ac09-8deb34692b76</version_id>
-  <version_modified>20190410T223306Z</version_modified>
+  <version_id>136b6e8c-1ea1-42ac-b250-72d00cd29d00</version_id>
+  <version_modified>20190411T203554Z</version_modified>
   <xml_checksum>B7427881</xml_checksum>
   <class_name>BiasedEconomizerSensorOAT</class_name>
   <display_name>Biased Economizer Sensor: Outdoor Temperature</display_name>
@@ -117,12 +117,6 @@
       <checksum>435C6B82</checksum>
     </file>
     <file>
-      <filename>ControllerOutdoorAirFlow_T.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>93360BB8</checksum>
-    </file>
-    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>1.5.0</identifier>
@@ -132,6 +126,12 @@
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
       <checksum>FDAB1CCD</checksum>
+    </file>
+    <file>
+      <filename>ControllerOutdoorAirFlow_T.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>74072FDF</checksum>
     </file>
   </files>
 </measure>

--- a/fault_measures_2017/BiasedEconomizerSensorOutdoorT/measure.xml
+++ b/fault_measures_2017/BiasedEconomizerSensorOutdoorT/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>biased_economizer_sensor_oat</name>
   <uid>75ad65c1-1f17-4fa3-be05-13a3bb415fbe</uid>
-  <version_id>136b6e8c-1ea1-42ac-b250-72d00cd29d00</version_id>
-  <version_modified>20190411T203554Z</version_modified>
+  <version_id>c3d2e6d1-57a5-4a1c-ad40-8377bae4b275</version_id>
+  <version_modified>20190411T215033Z</version_modified>
   <xml_checksum>B7427881</xml_checksum>
   <class_name>BiasedEconomizerSensorOAT</class_name>
   <display_name>Biased Economizer Sensor: Outdoor Temperature</display_name>
@@ -125,13 +125,13 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>FDAB1CCD</checksum>
+      <checksum>F4420CED</checksum>
     </file>
     <file>
       <filename>ControllerOutdoorAirFlow_T.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>74072FDF</checksum>
+      <checksum>1A6DF28C</checksum>
     </file>
   </files>
 </measure>

--- a/fault_measures_2017/BiasedEconomizerSensorOutdoorT/resources/ControllerOutdoorAirFlow_T.rb
+++ b/fault_measures_2017/BiasedEconomizerSensorOutdoorT/resources/ControllerOutdoorAirFlow_T.rb
@@ -112,7 +112,7 @@ def faultintensity_adjustmentfactor(string_objects, time_constant, time_step, st
   
 end
 
-def econ_t_sensor_bias_ems_main_body(runner, workspace, bias_sensor, controlleroutdoorair, t_bias=[0, 0], oacontrollername)
+def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorair, t_bias=[0, 0], oacontrollername)
 
   #workspace is the Workspace object in EnergyPlus Measure script
   
@@ -134,15 +134,15 @@ def econ_t_sensor_bias_ems_main_body(runner, workspace, bias_sensor, controllero
   econ_short_name = name_cut(econ_choice)
   main_body = "
     EnergyManagementSystem:Program,
-      t_bias"+name_cut(econ_choice)+"#{bias_sensor}_T, !- Name
+      t_bias"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype}, !- Name
       SET DELTASMALL = 0.00001, !- Program Line 1
       SET SMALLMASSFLOW = 0.001, !- Program Line 2
       SET SMALLVOLFLOW = 0.001, !- Program Line 3
       SET HIGHHUMCTRL = False, !- <none>
       SET NIGHTVENT = False, !- <none>
       SET ECON_OP = True, !- <none>
-      SET MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_T = "+name_cut(econ_choice)+"MixAirFlow_CTRL#{bias_sensor}_T, !- <none>
-      IF MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_T < SMALLMASSFLOW, !- Check if the duct has airflow
+      SET MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = "+name_cut(econ_choice)+"MixAirFlow_CTRL#{bias_sensor}_#{$faulttype}, !- <none>
+      IF MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} < SMALLMASSFLOW, !- Check if the duct has airflow
       SET FinalFlow = 0.00, !- <none>
       RETURN, !- <none>
       ENDIF, !- <none>
@@ -159,11 +159,11 @@ def econ_t_sensor_bias_ems_main_body(runner, workspace, bias_sensor, controllero
   end
   if bias_sensor.eql?("RET")
     main_body = main_body+"
-      SET RETTmp = "+name_cut(econ_choice)+"RETTemp1#{bias_sensor}_T"+ret_str_num+"*AF_current_#{$faulttype}_#{oacontrollername}, !- <none>
-      SET RETHumRat = "+name_cut(econ_choice)+"RETOmega1#{bias_sensor}_T, !- <none>
-      SET OATmp = "+name_cut(econ_choice)+"OATTemp1#{bias_sensor}_T, !- <none>
-      SET OAHumRat = "+name_cut(econ_choice)+"OATOmega1#{bias_sensor}_T, !- <none>
-      SET PTmp = "+name_cut(econ_choice)+"RETPressure1#{bias_sensor}_T, !- <none>
+      SET RETTmp = "+name_cut(econ_choice)+"RETTemp1#{bias_sensor}_#{$faulttype}"+ret_str_num+"*AF_current_#{$faulttype}_#{oacontrollername}, !- <none>
+      SET RETHumRat = "+name_cut(econ_choice)+"RETOmega1#{bias_sensor}_#{$faulttype}, !- <none>
+      SET OATmp = "+name_cut(econ_choice)+"OATTemp1#{bias_sensor}_#{$faulttype}, !- <none>
+      SET OAHumRat = "+name_cut(econ_choice)+"OATOmega1#{bias_sensor}_#{$faulttype}, !- <none>
+      SET PTmp = "+name_cut(econ_choice)+"RETPressure1#{bias_sensor}_#{$faulttype}, !- <none>
       IF PTmp < DELTASMALL, !- <none>
       SET PTmp = 101325.0, !- Zero pressure during warmup may crash the code
       ENDIF, !- <none>
@@ -179,11 +179,11 @@ def econ_t_sensor_bias_ems_main_body(runner, workspace, bias_sensor, controllero
     "
   elsif bias_sensor.eql?("OA")
     main_body = main_body+"
-	  SET RETTmp = "+name_cut(econ_choice)+"RETTemp1#{bias_sensor}_T, !- <none>
-      SET RETHumRat = "+name_cut(econ_choice)+"RETOmega1#{bias_sensor}_T, !- <none>
-      SET OATmp = "+name_cut(econ_choice)+"OATTemp1#{bias_sensor}_T"+oa_str_num+"*AF_current_#{$faulttype}_#{oacontrollername}, !- <none>
-      SET OAHumRat = "+name_cut(econ_choice)+"OATOmega1#{bias_sensor}_T, !- <none>
-      SET PTmp = "+name_cut(econ_choice)+"RETPressure1#{bias_sensor}_T, !- <none>
+	  SET RETTmp = "+name_cut(econ_choice)+"RETTemp1#{bias_sensor}_#{$faulttype}, !- <none>
+      SET RETHumRat = "+name_cut(econ_choice)+"RETOmega1#{bias_sensor}_#{$faulttype}, !- <none>
+      SET OATmp = "+name_cut(econ_choice)+"OATTemp1#{bias_sensor}_#{$faulttype}"+oa_str_num+"*AF_current_#{$faulttype}_#{oacontrollername}, !- <none>
+      SET OAHumRat = "+name_cut(econ_choice)+"OATOmega1#{bias_sensor}_#{$faulttype}, !- <none>
+      SET PTmp = "+name_cut(econ_choice)+"RETPressure1#{bias_sensor}_#{$faulttype}, !- <none>
       IF PTmp < DELTASMALL, !- <none>
       SET PTmp = 101325.0, !- Zero pressure during warmup may crash the code
       ENDIF, !- <none>
@@ -200,11 +200,11 @@ def econ_t_sensor_bias_ems_main_body(runner, workspace, bias_sensor, controllero
     "
   else  #for bias in both sensors
     main_body = main_body+"
-      SET RETTmp = "+name_cut(econ_choice)+"RETTemp1#{bias_sensor}_T"+ret_str_num+"*AF_current_#{$faulttype}_#{oacontrollername}, !- <none>
-      SET RETHumRat = "+name_cut(econ_choice)+"RETOmega1#{bias_sensor}_T, !- <none>
-      SET OATmp = "+name_cut(econ_choice)+"OATTemp1#{bias_sensor}_T"+oa_str_num+"*AF_current_#{$faulttype}_#{oacontrollername}, !- <none>
-      SET OAHumRat = "+name_cut(econ_choice)+"OATOmega1#{bias_sensor}_T, !- <none>
-      SET PTmp = "+name_cut(econ_choice)+"RETPressure1#{bias_sensor}_T, !- <none>
+      SET RETTmp = "+name_cut(econ_choice)+"RETTemp1#{bias_sensor}_#{$faulttype}"+ret_str_num+"*AF_current_#{$faulttype}_#{oacontrollername}, !- <none>
+      SET RETHumRat = "+name_cut(econ_choice)+"RETOmega1#{bias_sensor}_#{$faulttype}, !- <none>
+      SET OATmp = "+name_cut(econ_choice)+"OATTemp1#{bias_sensor}_#{$faulttype}"+oa_str_num+"*AF_current_#{$faulttype}_#{oacontrollername}, !- <none>
+      SET OAHumRat = "+name_cut(econ_choice)+"OATOmega1#{bias_sensor}_#{$faulttype}, !- <none>
+      SET PTmp = "+name_cut(econ_choice)+"RETPressure1#{bias_sensor}_#{$faulttype}, !- <none>
       IF PTmp < DELTASMALL, !- <none>
       SET PTmp = 101325.0, !- Zero pressure during warmup may crash the code
       ENDIF, !- <none>
@@ -222,12 +222,12 @@ def econ_t_sensor_bias_ems_main_body(runner, workspace, bias_sensor, controllero
     "
   end
   main_body = main_body+"
-      SET VDOT_DES = DesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_T, !- <none>
-      SET CMDOT_D = CMDesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_T, !- <none>
-      SET HMDOT_D = HMDesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_T, !- <none>
+      SET VDOT_DES = DesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype}, !- <none>
+      SET CMDOT_D = CMDesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype}, !- <none>
+      SET HMDOT_D = HMDesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype}, !- <none>
       SET MDOT_DES = @Max CMDOT_D HMDOT_D, !- <none>
-      SET MDOT_OA_MIN = MinOAMdot"+name_cut(econ_choice)+"#{bias_sensor}_T, !- <none>
-      SET MDOT_OA_MAX = MaxOAMdot"+name_cut(econ_choice)+"#{bias_sensor}_T, !- <none>
+      SET MDOT_OA_MIN = MinOAMdot"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype}, !- <none>
+      SET MDOT_OA_MAX = MaxOAMdot"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype}, !- <none>
       IF VDOT_DES > SMALLVOLFLOW, !- <none>
       SET MIN_FRAC = MDOT_OA_MIN/MDOT_DES, !- no if statement for airloop existence because the code won't work without an airloop
       SET MIN_FLOW = MDOT_OA_MIN, !- <none>
@@ -239,7 +239,7 @@ def econ_t_sensor_bias_ems_main_body(runner, workspace, bias_sensor, controllero
   
   if not controlleroutdoorair.getString(16).to_s.eql?("")  #Minimum Outdoor Air Schedule Name
     main_body = main_body+"
-      SET MIN_SCH_VALUE = "+name_cut(econ_choice)+"_MIN_SCH#{bias_sensor}_T, !- <none>
+      SET MIN_SCH_VALUE = "+name_cut(econ_choice)+"_MIN_SCH#{bias_sensor}_#{$faulttype}, !- <none>
       SET MIN_SCH_VALUE = @MAX MIN_SCH_VALUE 0.00, !- <none>
       SET MIN_SCH_VALUE = @MIN MIN_SCH_VALUE 1.00, !- <none>
       SET MIN_FRAC = MIN_SCH_VALUE*MIN_FRAC, !- <none>
@@ -269,7 +269,7 @@ def econ_t_sensor_bias_ems_main_body(runner, workspace, bias_sensor, controllero
               zone_name = name_cut(controllermechventilation.getString(4+3*i+1).to_s)
               if outdoorairspec.numFields == 7  #multiply the number with a schedule
                 main_body = main_body+"
-                  SET MECH_SCH = "+zone_name+"_OA_SCH#{bias_sensor}_T, !- NEED A SENSOR FOR THE SCHEDULE
+                  SET MECH_SCH = "+zone_name+"_OA_SCH#{bias_sensor}_#{$faulttype}, !- NEED A SENSOR FOR THE SCHEDULE
                 "
               else
                 main_body = main_body+"
@@ -278,9 +278,9 @@ def econ_t_sensor_bias_ems_main_body(runner, workspace, bias_sensor, controllero
               end
               if outdoorairspec.getString(1).to_s.eql?("Sum") #add code for summation
                 main_body = main_body+"
-                  SET ZONE_VOL = "+zone_name+"_VOL#{bias_sensor}_T, !- NEED INTERNAL VARIABLE FOR ZONE VOLUME
-                  SET ZONE_MUL = "+zone_name+"_MUL#{bias_sensor}_T, !- NEED INTERNAL VARIABLE FOR ZONE MULTIPLIER
-                  SET ZONE_LIST_MUL = "+zone_name+"_LIST_MUL#{bias_sensor}_T, !- NEED INTERNAL VARIABLE FOR ZONE LIST MULTIPLIER
+                  SET ZONE_VOL = "+zone_name+"_VOL#{bias_sensor}_#{$faulttype}, !- NEED INTERNAL VARIABLE FOR ZONE VOLUME
+                  SET ZONE_MUL = "+zone_name+"_MUL#{bias_sensor}_#{$faulttype}, !- NEED INTERNAL VARIABLE FOR ZONE MULTIPLIER
+                  SET ZONE_LIST_MUL = "+zone_name+"_LIST_MUL#{bias_sensor}_#{$faulttype}, !- NEED INTERNAL VARIABLE FOR ZONE LIST MULTIPLIER
 				"
 				#####################################################
 				if peoples.empty?
@@ -291,7 +291,7 @@ def econ_t_sensor_bias_ems_main_body(runner, workspace, bias_sensor, controllero
 				  peoples.each do |people|
 			        if people.getString(1).to_s.eql?(controllermechventilation.getString(4+3*i+1).to_s)
 				      main_body = main_body+"
-                        SET ZONE_PPL = "+zone_name+"_PEOPLE#{bias_sensor}_T, !- NEED SENSOR FOR ZONE People Occupant Count
+                        SET ZONE_PPL = "+zone_name+"_PEOPLE#{bias_sensor}_#{$faulttype}, !- NEED SENSOR FOR ZONE People Occupant Count
 				      "
 				    else
 				      main_body = main_body+"
@@ -305,7 +305,7 @@ def econ_t_sensor_bias_ems_main_body(runner, workspace, bias_sensor, controllero
                   SET IND_OA = #{outdoorairspec.getString(2).to_s}, !- Zone occupant flow rate
                   SET IND_OA = IND_OA*ZONE_MUL*ZONE_LIST_MUL*ZONE_PPL, !- <none>
                   SET OA_MECH = OA_MECH+IND_OA*MECH_SCH, !- <none>
-                  SET ZONE_AREA = "+zone_name+"_AREA#{bias_sensor}_T, !- NEED INTERNAL VARIABLE FOR ZONE FLOOR AREA
+                  SET ZONE_AREA = "+zone_name+"_AREA#{bias_sensor}_#{$faulttype}, !- NEED INTERNAL VARIABLE FOR ZONE FLOOR AREA
                   SET IND_OA = "+outdoorairspec.getString(3).to_s+"*ZONE_AREA, !- Zone floor area flow rate
                   SET IND_OA = IND_OA*ZONE_MUL*ZONE_LIST_MUL, !- <none>
                   SET OA_MECH = OA_MECH+IND_OA*MECH_SCH, !- <none>
@@ -319,14 +319,14 @@ def econ_t_sensor_bias_ems_main_body(runner, workspace, bias_sensor, controllero
               else #add code for maximum
                 main_body = main_body+"
                   SET IND_OA_FIN = 0.0, !- For maximum calculation
-                  SET ZONE_VOL = "+zone_name+"_VOL#{bias_sensor}_T, !- NEED INTERNAL VARIABLE FOR ZONE VOLUME
-                  SET ZONE_MUL = "+zone_name+"_MUL#{bias_sensor}_T, !- NEED INTERNAL VARIABLE FOR ZONE MULTIPLIER
-                  SET ZONE_LIST_MUL = "+zone_name+"_LIST_MUL#{bias_sensor}_T, !- NEED INTERNAL VARIABLE FOR ZONE LIST MULTIPLIER
-                  SET ZONE_PPL = "+zone_name+"_PEOPLE#{bias_sensor}_T, !- NEED SENSOR FOR ZONE People Occupant Count
+                  SET ZONE_VOL = "+zone_name+"_VOL#{bias_sensor}_#{$faulttype}, !- NEED INTERNAL VARIABLE FOR ZONE VOLUME
+                  SET ZONE_MUL = "+zone_name+"_MUL#{bias_sensor}_#{$faulttype}, !- NEED INTERNAL VARIABLE FOR ZONE MULTIPLIER
+                  SET ZONE_LIST_MUL = "+zone_name+"_LIST_MUL#{bias_sensor}_#{$faulttype}, !- NEED INTERNAL VARIABLE FOR ZONE LIST MULTIPLIER
+                  SET ZONE_PPL = "+zone_name+"_PEOPLE#{bias_sensor}_#{$faulttype}, !- NEED SENSOR FOR ZONE People Occupant Count
                   SET IND_OA = #{outdoorairspec.getString(2).to_s}, !- Zone occupant flow rate
                   SET IND_OA = IND_OA*ZONE_MUL*ZONE_LIST_MUL*ZONE_PPL, !- <none>
                   SET IND_OA_FIN = @Max IND_OA_FIN IND_OA, !- <none>
-                  SET ZONE_AREA = "+zone_name+"_AREA#{bias_sensor}_T, !- NEED INTERNAL VARIABLE FOR ZONE FLOOR AREA
+                  SET ZONE_AREA = "+zone_name+"_AREA#{bias_sensor}_#{$faulttype}, !- NEED INTERNAL VARIABLE FOR ZONE FLOOR AREA
                   SET IND_OA = "+outdoorairspec.getString(3).to_s+"*ZONE_AREA, !- Zone floor area flow rate
                   SET IND_OA = IND_OA*ZONE_MUL*ZONE_LIST_MUL, !- <none>
                   SET IND_OA_FIN = @Max IND_OA_FIN IND_OA, !- <none>
@@ -360,15 +360,15 @@ def econ_t_sensor_bias_ems_main_body(runner, workspace, bias_sensor, controllero
     SET TDiff = RETTmp-OATmp, !- <none>
     SET TDiff = @Abs TDiff, !- <none>
     IF TDiff > DELTASMALL, !- <none>
-    SET OA_SIGN = (RETTmp-"+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_T)/(RETTmp-OATmp), !- Initialize the signal
+    SET OA_SIGN = (RETTmp-"+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype})/(RETTmp-OATmp), !- Initialize the signal
     ELSE, !- <none>
-    IF RETTmp < "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_T && RETTmp >= OATmp, !- <none>
+    IF RETTmp < "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype} && RETTmp >= OATmp, !- <none>
     SET OA_SIGN = -1, !- <none>
-    ELSEIF RETTmp < "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_T && RETTmp < OATmp, !- <none>
+    ELSEIF RETTmp < "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype} && RETTmp < OATmp, !- <none>
     SET OA_SIGN = 1, !- <none>
-    ELSEIF RETTmp >= "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_T && RETTmp >= OATmp,
+    ELSEIF RETTmp >= "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype} && RETTmp >= OATmp,
     SET OA_SIGN = 1, !- <none>
-    ELSEIF RETTmp >= "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_T && RETTmp < OATmp,
+    ELSEIF RETTmp >= "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype} && RETTmp < OATmp,
     SET OA_SIGN = -1, !- <none>
     ENDIF, !- <none>
     ENDIF, !- <none>
@@ -408,7 +408,7 @@ def econ_t_sensor_bias_ems_main_body(runner, workspace, bias_sensor, controllero
                   if branch.getString(ii).to_s.eql?(oas_name)
                     airsystem_name = branch.getString(0).to_s.gsub(" Supply Branch","").gsub(" Main Branch","")
                     main_body = main_body+"
-                      SET LOCKOUT_POS = "+name_cut(airsystem_name)+"_Htg#{bias_sensor}_T, !- <none>
+                      SET LOCKOUT_POS = "+name_cut(airsystem_name)+"_Htg#{bias_sensor}_#{$faulttype}, !- <none>
                       IF LOCKOUT_POS > 0, !- <none>
                       SET NO_LOCK_OUT = False, !- <none>
                       ENDIF, !- <none>
@@ -417,7 +417,7 @@ def econ_t_sensor_bias_ems_main_body(runner, workspace, bias_sensor, controllero
                       #check if there is a compressor on the loop
                       #if there is, add code to check if the economizer should be locked out
                       main_body = main_body+"
-                        SET LOCKOUT_POS = "+name_cut(airsystem_name)+"_Ctg#{bias_sensor}_T, !- <none>
+                        SET LOCKOUT_POS = "+name_cut(airsystem_name)+"_Ctg#{bias_sensor}_#{$faulttype}, !- <none>
                         IF LOCKOUT_POS > 0, !- <none>
                         SET NO_LOCK_OUT = False, !- <none>
                         ENDIF, !- <none>
@@ -443,7 +443,7 @@ def econ_t_sensor_bias_ems_main_body(runner, workspace, bias_sensor, controllero
       SET HIGHHUMCTRL = False, !- <none>
       ELSE, !- Running the economizer
       SET ECON_OP = True, !- <none>
-      IF OATmp > "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_T, !- <none>
+      IF OATmp > "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype}, !- <none>
       SET OA_SIGN = 1, !- <none>
       ENDIF, !- <none>
     "
@@ -494,13 +494,13 @@ def econ_t_sensor_bias_ems_main_body(runner, workspace, bias_sensor, controllero
     end
     if controlleroutdoorair.getString(21).to_s.eql?("Yes")  #High humidity control check
       main_body = main_body+"
-        IF ZoneHumidLOAD"+name_cut(econ_choice)+"#{bias_sensor}_T < 0.0, !- High Humidity Control
+        IF ZoneHumidLOAD"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype} < 0.0, !- High Humidity Control
         SET HIGHHUMCTRL = True, !- <none>
         ENDIF, !- <none>
       "
       if controlleroutdoorair.getString(24).to_s.eql?("Yes")  #Control High Indoor Humidity Based on Outdoor Humidity Ratio
         main_body = main_body+"
-          IF ZoneHumid"+name_cut(econ_choice)+"#{bias_sensor}_T <= OAHumRat, !- Control High Indoor Humidity Based on Outdoor Humidity Ratio
+          IF ZoneHumid"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype} <= OAHumRat, !- Control High Indoor Humidity Based on Outdoor Humidity Ratio
           SET HIGHHUMCTRL = False, !- Set it back to False
           ENDIF, !- <none>
         "
@@ -508,7 +508,7 @@ def econ_t_sensor_bias_ems_main_body(runner, workspace, bias_sensor, controllero
     end
     if not controlleroutdoorair.getString(20).to_s.eql?("")  #Time of Day Economizer Control Schedule Name
       main_body = main_body+"
-        SET ECON_FLOW_SCH_VAL = ECONCTRL"+name_cut(econ_choice)+"_SCH#{bias_sensor}_T, !- <none>
+        SET ECON_FLOW_SCH_VAL = ECONCTRL"+name_cut(econ_choice)+"_SCH#{bias_sensor}_#{$faulttype}, !- <none>
         IF ECON_FLOW_SCH_VAL > 0, !- <none>
         SET OA_SIGN = 1.0, !- <none>
         SET ECON_OP = True, !- <none>
@@ -538,17 +538,17 @@ def econ_t_sensor_bias_ems_main_body(runner, workspace, bias_sensor, controllero
     IF NIGHTVENT == 0,
     IF OA_SIGN > MIN_FRAC,
     IF OA_SIGN < 1.0,
-    IF MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_T > SMALLMASSFLOW, !- Check if the duct has airflow
-    SET RETENTH_GB#{econ_short_name}#{bias_sensor}_T = ORI_RETENTH, !- to simulate feedback control, don't use measurement values
-    SET RETHUMRAT_GB#{econ_short_name}#{bias_sensor}_T = ORI_RETHumRat, !- to simulate feedback control, don't use measurement values
-    SET OAENTH_GB#{econ_short_name}#{bias_sensor}_T = ORI_OAENTH, !- to simulate feedback control, don't use measurement values
-    SET OAHUMRAT_GB#{econ_short_name}#{bias_sensor}_T = ORI_OAHumRat, !- to simulate feedback control, don't use measurement values
-    SET LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_T = MIN_FRAC, !- <none>
-    SET UPLIMIT_GB#{econ_short_name}#{bias_sensor}_T = 1, !- <none>
-    SET MIXTEMPSET_GB#{econ_short_name}#{bias_sensor}_T = "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_T, !-<none>
-    RUN EMSSolveRegulaFalsi_OA_SIGN#{econ_short_name}#{bias_sensor}_T, !- <none>
-    IF FLAG_GB#{econ_short_name}#{bias_sensor}_T > 0, !- <none>
-    SET OA_SIGN = SOLN_GB#{econ_short_name}#{bias_sensor}_T, !- <none>
+    IF MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} > SMALLMASSFLOW, !- Check if the duct has airflow
+    SET RETENTH_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = ORI_RETENTH, !- to simulate feedback control, don't use measurement values
+    SET RETHUMRAT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = ORI_RETHumRat, !- to simulate feedback control, don't use measurement values
+    SET OAENTH_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = ORI_OAENTH, !- to simulate feedback control, don't use measurement values
+    SET OAHUMRAT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = ORI_OAHumRat, !- to simulate feedback control, don't use measurement values
+    SET LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = MIN_FRAC, !- <none>
+    SET UPLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = 1, !- <none>
+    SET MIXTEMPSET_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype}, !-<none>
+    RUN EMSSolveRegulaFalsi_OA_SIGN#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+    IF FLAG_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} > 0, !- <none>
+    SET OA_SIGN = SOLN_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
     ENDIF,
     ENDIF,
     ENDIF,
@@ -568,10 +568,10 @@ def econ_t_sensor_bias_ems_main_body(runner, workspace, bias_sensor, controllero
   if controlleroutdoorair.getString(21).to_s.eql?("Yes")  #High humidity control check
     main_body = main_body+"
       IF HIGHHUMCTRL == True, !- high humidity control
-      SET MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_T = "+name_cut(econ_choice)+"MixAirFlow_CTRL#{bias_sensor}_T, !- <none>
+      SET MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = "+name_cut(econ_choice)+"MixAirFlow_CTRL#{bias_sensor}_#{$faulttype}, !- <none>
       SET OA_SIGN_CAN = "+controlleroutdoorair.getString(23).to_s+", !- <none>
       SET OA_SIGN_CAN = OA_SIGN_CAN*MDOT_OA_MAX, !- <none>
-      SET OA_SIGN_CAN = OA_SIGN_CAN/MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_T, !- <none>
+      SET OA_SIGN_CAN = OA_SIGN_CAN/MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
       SET OA_SIGN = @MAX OA_SIGN_CAN MIN_FRAC, !- <none>
       ENDIF,
     "
@@ -594,12 +594,12 @@ def econ_t_sensor_bias_ems_main_body(runner, workspace, bias_sensor, controllero
   
   if not controlleroutdoorair.getString(17).to_s.eql?("")  #Minimum Fraction of Outdoor Air Schedule Name
     main_body = main_body+"
-      SET MIN_SCH_VALUE = "+name_cut(econ_choice)+"_MIN_FRAC_SCH#{bias_sensor}_T, !- <none>
+      SET MIN_SCH_VALUE = "+name_cut(econ_choice)+"_MIN_FRAC_SCH#{bias_sensor}_#{$faulttype}, !- <none>
       SET MIN_SCH_VALUE = @Max MIN_SCH_VALUE 0.0, !- <none>
       SET MIN_SCH_VALUE = @Min MIN_SCH_VALUE 1.0, !- <none>
       IF MIN_SCH_VALUE > MIN_FRAC, !- <none>
       SET MIN_FRAC = MIN_SCH_VALUE, !- <none>
-      SET MDOT_OA_MIN = MIN_FRAC*MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_T, !- <none>
+      SET MDOT_OA_MIN = MIN_FRAC*MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
       ENDIF, !- <none>
       SET OA_SIGN = @Max OA_SIGN MIN_FRAC, !- <none>
     "
@@ -607,12 +607,12 @@ def econ_t_sensor_bias_ems_main_body(runner, workspace, bias_sensor, controllero
   
   if not controlleroutdoorair.getString(18).to_s.eql?("")  #Maximum Fraction of Outdoor Air Schedule Name
     main_body = main_body+"
-      SET MAX_SCH_VALUE = "+name_cut(econ_choice)+"_MAX_FRAC_SCH#{bias_sensor}_T, !- <none>
+      SET MAX_SCH_VALUE = "+name_cut(econ_choice)+"_MAX_FRAC_SCH#{bias_sensor}_#{$faulttype}, !- <none>
       SET MAX_SCH_VALUE = @Max MAX_SCH_VALUE 0.0, !- <none>
       SET MAX_SCH_VALUE = @Min MAX_SCH_VALUE 1.0, !- <none>
       IF MIN_FRAC > MAX_SCH_VALUE, !- <none>
       SET MIN_FRAC = MAX_SCH_VALUE, !- <none>
-      SET MDOT_OA_MIN = MIN_FRAC*MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_T, !- <none>
+      SET MDOT_OA_MIN = MIN_FRAC*MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
       ENDIF, !- <none>
       SET OA_SIGN = @Min OA_SIGN MAX_SCH_VALUE, !- <none>
     "
@@ -620,14 +620,14 @@ def econ_t_sensor_bias_ems_main_body(runner, workspace, bias_sensor, controllero
   
   #calculate the outdoor airflow rate
   main_body = main_body+"
-    SET FinalFlow = OA_SIGN*MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_T, !- <none>
+    SET FinalFlow = OA_SIGN*MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
   "
   
   #make sure that it doesn't exceed the limits of ventilation
   if not controlleroutdoorair.getString(19).to_s.eql?("")
     main_body = main_body+"
       IF OA_MECH > FinalFlow, !- <none>
-      SET FinalFlow = @Min OA_MECH MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_T, !- <none>
+      SET FinalFlow = @Min OA_MECH MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
       ENDIF, !- <none>
     "
   end
@@ -638,7 +638,7 @@ def econ_t_sensor_bias_ems_main_body(runner, workspace, bias_sensor, controllero
   if controlleroutdoorair.getString(15).to_s.eql?("FixedMinimum")
     main_body = main_body+"
       SET OA_NEW = FinalFlow, !- <none>
-      SET DUMMY = MinOAMdot"+name_cut(econ_choice)+"#{bias_sensor}_T, !- Name too long
+      SET DUMMY = MinOAMdot"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype}, !- Name too long
       SET OA_NEW = @Max OA_NEW (DUMMY*MIN_SCH_VALUE), !- <none>
       SET FinalFlow = OA_NEW, !- <none>
     "
@@ -647,7 +647,7 @@ def econ_t_sensor_bias_ems_main_body(runner, workspace, bias_sensor, controllero
   #check with mixed airflow
   main_body = main_body+"
     SET OA_NEW = FinalFlow, !- <none>
-    SET OA_NEW = @Min OA_NEW MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_T, !- <none>
+    SET OA_NEW = @Min OA_NEW MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
     SET FinalFlow = OA_NEW, !- <none>
   "
   
@@ -663,7 +663,7 @@ def econ_t_sensor_bias_ems_main_body(runner, workspace, bias_sensor, controllero
     SET OA_NEW = @Min MDOT_OA_MAX OA_NEW, !- <none>
     SET FinalFlow = OA_NEW, !- <none>
     ENDIF, !- <none>
-    SET "+name_cut(econ_choice)+"MDOT_OA#{bias_sensor}_T = FinalFlow; !- <none>
+    SET "+name_cut(econ_choice)+"MDOT_OA#{bias_sensor}_#{$faulttype} = FinalFlow; !- <none>
   "
   
   return main_body
@@ -784,17 +784,17 @@ def econ_t_sensor_bias_ems_other(string_objects, workspace, bias_sensor, control
   
   string_objects << "
     EnergyManagementSystem:Subroutine,
-      RES_OA_SIGN#{econ_short_name}#{bias_sensor}_T, !- Name
-      SET TEMP_OA_SIGN = OA_SIGN_GB#{econ_short_name}#{bias_sensor}_T, !- <none>
-      SET TEMP_MIX_FLOW = MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_T, !- <none>
+      RES_OA_SIGN#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- Name
+      SET TEMP_OA_SIGN = OA_SIGN_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      SET TEMP_MIX_FLOW = MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
       SET TEMP_OA_FLOW = TEMP_OA_SIGN*TEMP_MIX_FLOW, !- <none>
       SET RECFLOW1 = 0, !- <none>
       SET RECFLOW2 = TEMP_MIX_FLOW-TEMP_OA_FLOW, !- <none>
       SET RECIR_FLOW = @MAX RECFLOW1 RECFLOW2, !- <none>
-      SET TEMP_RETENTH = RETENTH_GB#{econ_short_name}#{bias_sensor}_T, !- <none>
-      SET TEMP_RETHUMRAT = RETHUMRAT_GB#{econ_short_name}#{bias_sensor}_T, !- <none>
-      SET TEMP_OAENTH = OAENTH_GB#{econ_short_name}#{bias_sensor}_T, !- <none>
-      SET TEMP_OAHUMRAT = OAHUMRAT_GB#{econ_short_name}#{bias_sensor}_T, !- <none>
+      SET TEMP_RETENTH = RETENTH_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      SET TEMP_RETHUMRAT = RETHUMRAT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      SET TEMP_OAENTH = OAENTH_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      SET TEMP_OAHUMRAT = OAHUMRAT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
       SET TEMP_MIXENTH = RECIR_FLOW*TEMP_RETENTH, !- <none>
       SET TEMP_MIXENTH = TEMP_MIXENTH+TEMP_OA_FLOW*TEMP_OAENTH, !- <none>
       SET TEMP_MIXENTH = TEMP_MIXENTH/TEMP_MIX_FLOW, !- <none>
@@ -802,23 +802,23 @@ def econ_t_sensor_bias_ems_other(string_objects, workspace, bias_sensor, control
       SET TEMP_MIXHUMRAT = TEMP_MIXHUMRAT+TEMP_OA_FLOW*TEMP_OAHUMRAT, !- <none>
       SET TEMP_MIXHUMRAT = TEMP_MIXHUMRAT/TEMP_MIX_FLOW, !- <none>
       SET TEMP_MIXTEMP = @TdbFnHW TEMP_MIXENTH TEMP_MIXHUMRAT, !- <none>
-      SET TEMP_AA = MIXTEMPSET_GB#{econ_short_name}#{bias_sensor}_T-TEMP_MIXTEMP, !- <none>
-      SET RESIDUAL_GB#{econ_short_name}#{bias_sensor}_T = TEMP_AA; !- <none>
+      SET TEMP_AA = MIXTEMPSET_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}-TEMP_MIXTEMP, !- <none>
+      SET RESIDUAL_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = TEMP_AA; !- <none>
   "
   
   string_objects << "
     EnergyManagementSystem:Subroutine,
-      EMSSolveRegulaFalsi_OA_SIGN#{econ_short_name}#{bias_sensor}_T, !- Name
-      SET OA_SIGN_GB#{econ_short_name}#{bias_sensor}_T = LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_T, !- <none>
-      RUN RES_OA_SIGN#{econ_short_name}#{bias_sensor}_T, !- <none>
-      SET Y0 = RESIDUAL_GB#{econ_short_name}#{bias_sensor}_T, !- <none>
-      SET OA_SIGN_GB#{econ_short_name}#{bias_sensor}_T = UPLIMIT_GB#{econ_short_name}#{bias_sensor}_T, !- <none>
-      RUN RES_OA_SIGN#{econ_short_name}#{bias_sensor}_T, !- <none>
-      SET Y1 = RESIDUAL_GB#{econ_short_name}#{bias_sensor}_T, !- <none>
+      EMSSolveRegulaFalsi_OA_SIGN#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- Name
+      SET OA_SIGN_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      RUN RES_OA_SIGN#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      SET Y0 = RESIDUAL_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      SET OA_SIGN_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = UPLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      RUN RES_OA_SIGN#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      SET Y1 = RESIDUAL_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
       SET PROD = Y0*Y1, !- <none>
       IF Y0*Y1 > 0, !- <none>
-      SET FLAG_GB#{econ_short_name}#{bias_sensor}_T = -2, !- <none>
-      SET SOLN_GB#{econ_short_name}#{bias_sensor}_T = LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_T, !- <none>
+      SET FLAG_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = -2, !- <none>
+      SET SOLN_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
       RETURN, ! Error for solution
       ENDIF, !- <none>
       SET CONT = 1, !- <none>
@@ -832,11 +832,11 @@ def econ_t_sensor_bias_ems_other(string_objects, workspace, bias_sensor, control
       SET DY = 1.d-10, !- <none>
       ENDIF, !- <none>
       ENDIF, !- <none>
-      SET XTemp = Y0*UPLIMIT_GB#{econ_short_name}#{bias_sensor}_T, !- <none>
-      SET XTemp = (XTemp-Y1*LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_T)/DY, !- <none>
-      SET OA_SIGN_GB#{econ_short_name}#{bias_sensor}_T = XTemp, !- <none>
-      RUN RES_OA_SIGN#{econ_short_name}#{bias_sensor}_T, !- <none>
-      SET YTemp = RESIDUAL_GB#{econ_short_name}#{bias_sensor}_T, !- <none>
+      SET XTemp = Y0*UPLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      SET XTemp = (XTemp-Y1*LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype})/DY, !- <none>
+      SET OA_SIGN_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = XTemp, !- <none>
+      RUN RES_OA_SIGN#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      SET YTemp = RESIDUAL_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
       SET NITE = NITE+1, !- <none>
       IF YTemp < 0.0001 && YTemp+0.0001 > 0, !- <none>
       SET CONT = 0, !- <none>
@@ -847,101 +847,101 @@ def econ_t_sensor_bias_ems_other(string_objects, workspace, bias_sensor, control
       IF CONT > 0.0d0, !- <none>
       IF Y0 < 0.0d0, !- <none>
       IF YTemp < 0.0d0, !- <none>
-      SET LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_T = XTemp, !- <none>
+      SET LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = XTemp, !- <none>
       SET Y0 = YTemp, !- <none>
       ELSE, !- <none>
-      SET UPLIMIT_GB#{econ_short_name}#{bias_sensor}_T = XTemp, !- <none>
+      SET UPLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = XTemp, !- <none>
       SET Y1 = YTemp, !- <none>
       ENDIF, !- <none>
       ELSE, !- <none>
       IF YTemp < 0.0d0, !- <none>
-      SET UPLIMIT_GB#{econ_short_name}#{bias_sensor}_T = XTemp, !- <none>
+      SET UPLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = XTemp, !- <none>
       SET Y1 = YTemp, !- <none>
       ELSE, !- <none>
-      SET LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_T = XTemp, !- <none>
+      SET LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = XTemp, !- <none>
       SET Y0 = YTemp, !- <none>
       ENDIF, !- <none>
       ENDIF, !- <none>
       ENDIF, !- <none>
       ENDWHILE, !- <none>
       IF CONV == 1, !- <none>
-      SET FLAG_GB#{econ_short_name}#{bias_sensor}_T = NITE, !- <none>
+      SET FLAG_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = NITE, !- <none>
       ELSE,
-      SET FLAG_GB#{econ_short_name}#{bias_sensor}_T = -1, !- <none>
+      SET FLAG_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = -1, !- <none>
       ENDIF, !- <none>
-      SET SOLN_GB#{econ_short_name}#{bias_sensor}_T = XTemp; !- <none>
+      SET SOLN_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = XTemp; !- <none>
   "
   
   string_objects << "
     EnergyManagementSystem:ProgramCallingManager,
-      EMSCallt_bias"+name_cut(econ_choice)+"#{bias_sensor}_T, !- Name
+      EMSCallt_bias"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype}, !- Name
       InsideHVACSystemIterationLoop,       !- EnergyPlus Model Calling Point
-      t_bias"+name_cut(econ_choice)+"#{bias_sensor}_T, !- Name
+      t_bias"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype}, !- Name
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      RESIDUAL_GB#{econ_short_name}#{bias_sensor}_T;
+      RESIDUAL_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_T;
+      LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      UPLIMIT_GB#{econ_short_name}#{bias_sensor}_T;
+      UPLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      FLAG_GB#{econ_short_name}#{bias_sensor}_T;
+      FLAG_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      SOLN_GB#{econ_short_name}#{bias_sensor}_T;
+      SOLN_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      OA_SIGN_GB#{econ_short_name}#{bias_sensor}_T;
+      OA_SIGN_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_T;
+      MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      RETENTH_GB#{econ_short_name}#{bias_sensor}_T;
+      RETENTH_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      RETHUMRAT_GB#{econ_short_name}#{bias_sensor}_T;
+      RETHUMRAT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      OAENTH_GB#{econ_short_name}#{bias_sensor}_T;
+      OAENTH_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      OAHUMRAT_GB#{econ_short_name}#{bias_sensor}_T;
+      OAHUMRAT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      MIXTEMPSET_GB#{econ_short_name}#{bias_sensor}_T;
+      MIXTEMPSET_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "   
     EnergyManagementSystem:Actuator,
-      "+name_cut(econ_choice)+"MDOT_OA#{bias_sensor}_T,        !- Name
+      "+name_cut(econ_choice)+"MDOT_OA#{bias_sensor}_#{$faulttype},        !- Name
       "+econ_choice+", !- Actuated Component Unique Name
       Outdoor Air Controller,                                  !- Actuated Component Type
       Air Mass Flow Rate;                           !- Actuated Component Control Type
@@ -978,35 +978,35 @@ def econ_t_sensor_bias_ems_other(string_objects, workspace, bias_sensor, control
   
   string_objects << "
     EnergyManagementSystem:InternalVariable,
-      DesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_T,
+      DesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype},
       "+airsystem_name+",
       Intermediate Air System Main Supply Volume Flow Rate;
   "
   
   string_objects << "
     EnergyManagementSystem:InternalVariable,
-      CMDesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_T,
+      CMDesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype},
       "+airsystem_name+",
       Intermediate Air System "+sizing_option+" Peak Cooling Mass Flow Rate;
   "
   
   string_objects << "
     EnergyManagementSystem:InternalVariable,
-      HMDesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_T,
+      HMDesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype},
       "+airsystem_name+",
       Intermediate Air System "+sizing_option+" Peak Heating Mass Flow Rate;
   "
   
   string_objects << "
     EnergyManagementSystem:InternalVariable,
-      MinOAMdot"+name_cut(econ_choice)+"#{bias_sensor}_T,
+      MinOAMdot"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype},
       "+econ_choice+",
       Outdoor Air Controller Minimum Mass Flow Rate;
   "
   
   string_objects << "
     EnergyManagementSystem:InternalVariable,
-      MaxOAMdot"+name_cut(econ_choice)+"#{bias_sensor}_T,
+      MaxOAMdot"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype},
       "+econ_choice+",
       Outdoor Air Controller Maximum Mass Flow Rate;
   "
@@ -1032,45 +1032,44 @@ def econ_t_sensor_bias_ems_other(string_objects, workspace, bias_sensor, control
               zone_name_tag = name_cut(zone_name)
               string_objects << "
                 EnergyManagementSystem:InternalVariable,
-                  "+zone_name_tag+"_VOL#{bias_sensor}_T,
+                  "+zone_name_tag+"_VOL#{bias_sensor}_#{$faulttype},
                   "+zone_name+",
                   Zone Air Volume;
               "
               string_objects << "
                 EnergyManagementSystem:InternalVariable,
-                  "+zone_name_tag+"_MUL#{bias_sensor}_T,
+                  "+zone_name_tag+"_MUL#{bias_sensor}_#{$faulttype},
                   "+zone_name+",
                   Zone Multiplier;
               "
               string_objects << "
                 EnergyManagementSystem:InternalVariable,
-                  "+zone_name_tag+"_LIST_MUL#{bias_sensor}_T,
+                  "+zone_name_tag+"_LIST_MUL#{bias_sensor}_#{$faulttype},
                   "+zone_name+",
                   Zone List Multiplier;
               "
               string_objects << "
                 EnergyManagementSystem:InternalVariable,
-                  "+zone_name_tag+"_AREA#{bias_sensor}_T,
+                  "+zone_name_tag+"_AREA#{bias_sensor}_#{$faulttype},
                   "+zone_name+",
                   Zone Floor Area;
               "
-			  #####################################################
+              #####################################################
               peoples.each do |people|
 			    if people.getString(1).to_s.eql?(zone_name)
 				  people_name = people.getString(0).to_s
 				  string_objects << "
                     EnergyManagementSystem:Sensor,
-                    "+zone_name_tag+"_PEOPLE#{bias_sensor}_T, !- Name
+                    "+zone_name_tag+"_PEOPLE#{bias_sensor}_#{$faulttype}, !- Name
                     "+people_name+",                        !- Output:Variable or Output:Meter Index Key Name
                     Zone People Occupant Count;                !- Output:Variable or Output:Meter Name
                   "
 				end
 			  end
 			  #####################################################
-			  
               string_objects << "
                 EnergyManagementSystem:Sensor,
-                  "+zone_name_tag+"_OA_SCH#{bias_sensor}_T, !- Name
+                  "+zone_name_tag+"_OA_SCH#{bias_sensor}_#{$faulttype}, !- Name
                   "+oaschedule_name+",                        !- Output:Variable or Output:Meter Index Key Name
                   Schedule Value;                !- Output:Variable or Output:Meter Name
               "
@@ -1083,14 +1082,14 @@ def econ_t_sensor_bias_ems_other(string_objects, workspace, bias_sensor, control
   
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(airsystem_name)+"_Htg#{bias_sensor}_T,
+      "+name_cut(airsystem_name)+"_Htg#{bias_sensor}_#{$faulttype},
       "+airsystem_name+",
       Air System Heating Coil Total Heating Energy;
   "
   
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(airsystem_name)+"_Ctg#{bias_sensor}_T,
+      "+name_cut(airsystem_name)+"_Ctg#{bias_sensor}_#{$faulttype},
       "+airsystem_name+",
       Air System Cooling Coil Total Cooling Energy;
   "
@@ -1098,21 +1097,21 @@ def econ_t_sensor_bias_ems_other(string_objects, workspace, bias_sensor, control
   ret_node_name = controlleroutdoorair.getString(2).to_s
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(econ_choice)+"RETTemp1#{bias_sensor}_T,  !- Name
+      "+name_cut(econ_choice)+"RETTemp1#{bias_sensor}_#{$faulttype},  !- Name
       "+ret_node_name+",                        !- Output:Variable or Output:Meter Index Key Name
       System Node Temperature;                !- Output:Variable or Output:Meter Name
   "
   
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(econ_choice)+"RETOmega1#{bias_sensor}_T,  !- Name
+      "+name_cut(econ_choice)+"RETOmega1#{bias_sensor}_#{$faulttype},  !- Name
       "+ret_node_name+",                        !- Output:Variable or Output:Meter Index Key Name
       System Node Humidity Ratio;                !- Output:Variable or Output:Meter Name
   "
   
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(econ_choice)+"RETPressure1#{bias_sensor}_T,  !- Name
+      "+name_cut(econ_choice)+"RETPressure1#{bias_sensor}_#{$faulttype},  !- Name
       "+ret_node_name+",                        !- Output:Variable or Output:Meter Index Key Name
       System Node Pressure;                !- Output:Variable or Output:Meter Name
   "
@@ -1120,7 +1119,7 @@ def econ_t_sensor_bias_ems_other(string_objects, workspace, bias_sensor, control
   mx_node_name = controlleroutdoorair.getString(3).to_s
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_T,  !- Name
+      "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype},  !- Name
       "+mx_node_name+",                        !- Output:Variable or Output:Meter Index Key Name
       System Node Setpoint Temperature;                !- Output:Variable or Output:Meter Name
   "
@@ -1128,21 +1127,21 @@ def econ_t_sensor_bias_ems_other(string_objects, workspace, bias_sensor, control
   oa_node_name = controlleroutdoorair.getString(4).to_s
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(econ_choice)+"OATTemp1#{bias_sensor}_T,  !- Name
+      "+name_cut(econ_choice)+"OATTemp1#{bias_sensor}_#{$faulttype},  !- Name
       "+oa_node_name+",                        !- Output:Variable or Output:Meter Index Key Name
       System Node Temperature;                !- Output:Variable or Output:Meter Name
   "
   
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(econ_choice)+"OATOmega1#{bias_sensor}_T,  !- Name
+      "+name_cut(econ_choice)+"OATOmega1#{bias_sensor}_#{$faulttype},  !- Name
       "+oa_node_name+",                        !- Output:Variable or Output:Meter Index Key Name
       System Node Humidity Ratio;                !- Output:Variable or Output:Meter Name
   "
   
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(econ_choice)+"MixAirFlow_CTRL#{bias_sensor}_T,  !- Name
+      "+name_cut(econ_choice)+"MixAirFlow_CTRL#{bias_sensor}_#{$faulttype},  !- Name
       "+airsystem_name+",                        !- Output:Variable or Output:Meter Index Key Name
       Air System Mixed Air Mass Flow Rate;                !- Output:Variable or Output:Meter Name
   "
@@ -1153,7 +1152,7 @@ def econ_t_sensor_bias_ems_other(string_objects, workspace, bias_sensor, control
     # check high humidity control before adding
     string_objects << "
       EnergyManagementSystem:Sensor,
-        ZoneHumid"+name_cut(econ_choice)+"#{bias_sensor}_T,  !- Name
+        ZoneHumid"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype},  !- Name
         "+humidistat_zone+",                        !- Output:Variable or Output:Meter Index Key Name
         Zone Air Humidity Ratio;                !- Output:Variable or Output:Meter Name
     "
@@ -1161,7 +1160,7 @@ def econ_t_sensor_bias_ems_other(string_objects, workspace, bias_sensor, control
     # check high humidity control before adding
     string_objects << "
       EnergyManagementSystem:Sensor,
-        ZoneHumidLOAD"+name_cut(econ_choice)+"#{bias_sensor}_T,  !- Name
+        ZoneHumidLOAD"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype},  !- Name
         "+humidistat_zone+",                        !- Output:Variable or Output:Meter Index Key Name
         Zone Predicted Moisture Load to Humidifying Setpoint Moisture Transfer Rate;                !- Output:Variable or Output:Meter Name
     "
@@ -1171,7 +1170,7 @@ def econ_t_sensor_bias_ems_other(string_objects, workspace, bias_sensor, control
   if not controlleroutdoorair.getString(20).to_s.eql?("")
     string_objects << "
       EnergyManagementSystem:Sensor,
-        ECONCTRL"+name_cut(econ_choice)+"_SCH#{bias_sensor}_T, !- Name
+        ECONCTRL"+name_cut(econ_choice)+"_SCH#{bias_sensor}_#{$faulttype}, !- Name
         "+controlleroutdoorair.getString(20).to_s+", !- Schedule Name
         Schedule Value; !- Output:Variable
     "
@@ -1181,7 +1180,7 @@ def econ_t_sensor_bias_ems_other(string_objects, workspace, bias_sensor, control
   if false
     string_objects << "
       EnergyManagementSystem:Sensor,
-        NIGHTVENT_SCH#{bias_sensor}_T, !- Name
+        NIGHTVENT_SCH#{bias_sensor}_#{$faulttype}, !- Name
         [Schedule name from Ruby], !- Schedule Name
         Schedule Value; !- Output:Variable
     "
@@ -1191,7 +1190,7 @@ def econ_t_sensor_bias_ems_other(string_objects, workspace, bias_sensor, control
   if not controlleroutdoorair.getString(18).to_s.eql?("")
     string_objects << "
       EnergyManagementSystem:Sensor,
-        "+name_cut(econ_choice)+"_MAX_FRAC_SCH#{bias_sensor}_T, !- Name
+        "+name_cut(econ_choice)+"_MAX_FRAC_SCH#{bias_sensor}_#{$faulttype}, !- Name
         "+controlleroutdoorair.getString(18).to_s+", !- Schedule Name
         Schedule Value; !- Output:Variable
     "
@@ -1201,7 +1200,7 @@ def econ_t_sensor_bias_ems_other(string_objects, workspace, bias_sensor, control
   if not controlleroutdoorair.getString(16).to_s.eql?("")
     string_objects << "
       EnergyManagementSystem:Sensor,
-        "+name_cut(econ_choice)+"_MIN_SCH#{bias_sensor}_T, !- Name
+        "+name_cut(econ_choice)+"_MIN_SCH#{bias_sensor}_#{$faulttype}, !- Name
         "+controlleroutdoorair.getString(16).to_s+", !- Schedule Name
         Schedule Value; !- Output:Variable
     "
@@ -1211,7 +1210,7 @@ def econ_t_sensor_bias_ems_other(string_objects, workspace, bias_sensor, control
   if not controlleroutdoorair.getString(17).to_s.eql?("")
     string_objects << "
       EnergyManagementSystem:Sensor,
-        "+name_cut(econ_choice)+"_MIN_FRAC_SCH#{bias_sensor}_T, !- Name
+        "+name_cut(econ_choice)+"_MIN_FRAC_SCH#{bias_sensor}_#{$faulttype}, !- Name
         "+controlleroutdoorair.getString(17).to_s+", !- Schedule Name
         Schedule Value; !- Output:Variable
     "

--- a/fault_measures_2017/BiasedEconomizerSensorReturnRH/measure.xml
+++ b/fault_measures_2017/BiasedEconomizerSensorReturnRH/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>biased_economizer_sensor_return_rh</name>
   <uid>581a85db-9cee-480f-9e5f-bbf62b217268</uid>
-  <version_id>67f6c6ee-a671-46a2-af79-c7279a1a3f86</version_id>
-  <version_modified>20190411T203253Z</version_modified>
+  <version_id>d1fe1ba2-5c10-43cd-b0fc-fac3fd226249</version_id>
+  <version_modified>20190411T205422Z</version_modified>
   <xml_checksum>B7427881</xml_checksum>
   <class_name>BiasedEconomizerSensorReturnRH</class_name>
   <display_name>Biased Economizer Sensor: Return RH</display_name>
@@ -131,7 +131,7 @@
       <filename>ControllerOutdoorAirFlow_RH.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>1659F2C7</checksum>
+      <checksum>1C0D0879</checksum>
     </file>
   </files>
 </measure>

--- a/fault_measures_2017/BiasedEconomizerSensorReturnRH/measure.xml
+++ b/fault_measures_2017/BiasedEconomizerSensorReturnRH/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>biased_economizer_sensor_return_rh</name>
   <uid>581a85db-9cee-480f-9e5f-bbf62b217268</uid>
-  <version_id>af1d293e-082c-423e-a16d-8c1198dc7eb1</version_id>
-  <version_modified>20190410T223832Z</version_modified>
+  <version_id>67f6c6ee-a671-46a2-af79-c7279a1a3f86</version_id>
+  <version_modified>20190411T203253Z</version_modified>
   <xml_checksum>B7427881</xml_checksum>
   <class_name>BiasedEconomizerSensorReturnRH</class_name>
   <display_name>Biased Economizer Sensor: Return RH</display_name>
@@ -117,12 +117,6 @@
       <checksum>435C6B82</checksum>
     </file>
     <file>
-      <filename>ControllerOutdoorAirFlow_RH.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>F67D394D</checksum>
-    </file>
-    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>1.5.0</identifier>
@@ -132,6 +126,12 @@
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
       <checksum>5ABEC491</checksum>
+    </file>
+    <file>
+      <filename>ControllerOutdoorAirFlow_RH.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>1659F2C7</checksum>
     </file>
   </files>
 </measure>

--- a/fault_measures_2017/BiasedEconomizerSensorReturnRH/measure.xml
+++ b/fault_measures_2017/BiasedEconomizerSensorReturnRH/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>biased_economizer_sensor_return_rh</name>
   <uid>581a85db-9cee-480f-9e5f-bbf62b217268</uid>
-  <version_id>d1fe1ba2-5c10-43cd-b0fc-fac3fd226249</version_id>
-  <version_modified>20190411T205422Z</version_modified>
+  <version_id>c23145e1-9851-4a25-afa3-6f38a737e820</version_id>
+  <version_modified>20190415T162050Z</version_modified>
   <xml_checksum>B7427881</xml_checksum>
   <class_name>BiasedEconomizerSensorReturnRH</class_name>
   <display_name>Biased Economizer Sensor: Return RH</display_name>
@@ -131,7 +131,7 @@
       <filename>ControllerOutdoorAirFlow_RH.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>1C0D0879</checksum>
+      <checksum>E613A825</checksum>
     </file>
   </files>
 </measure>

--- a/fault_measures_2017/BiasedEconomizerSensorReturnRH/resources/ControllerOutdoorAirFlow_RH.rb
+++ b/fault_measures_2017/BiasedEconomizerSensorReturnRH/resources/ControllerOutdoorAirFlow_RH.rb
@@ -136,23 +136,23 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
   econ_short_name = name_cut(econ_choice)
   main_body = "
     EnergyManagementSystem:Program,
-      RH_BIAS"+name_cut(econ_choice)+"#{bias_sensor}_RH, !- Name
+      RH_BIAS"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype}, !- Name
       SET DELTASMALL = 0.00001, !- Program Line 1
       SET SMALLMASSFLOW = 0.001, !- Program Line 2
       SET SMALLVOLFLOW = 0.001, !- Program Line 3
       SET HIGHHUMCTRL = False, !- <none>
       SET NIGHTVENT = False, !- <none>
       SET ECON_OP = True, !- <none>
-      SET MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_RH = "+name_cut(econ_choice)+"MixAirFlow_CTRL#{bias_sensor}_RH, !- <none>
-      IF MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_RH < SMALLMASSFLOW, !- Check if the duct has airflow
+      SET MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = "+name_cut(econ_choice)+"MixAirFlow_CTRL#{bias_sensor}_#{$faulttype}, !- <none>
+      IF MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} < SMALLMASSFLOW, !- Check if the duct has airflow
       SET FinalFlow = 0.00, !- <none>
       RETURN, !- <none>
       ENDIF, !- <none>
-      SET RETTmp = "+name_cut(econ_choice)+"RETTemp1#{bias_sensor}_RH, !- <none>
-      SET RETHumRat = "+name_cut(econ_choice)+"RETOmega1#{bias_sensor}_RH, !- <none>
-      SET OATmp = "+name_cut(econ_choice)+"OATTemp1#{bias_sensor}_RH, !- <none>
-      SET OAHumRat = "+name_cut(econ_choice)+"OATOmega1#{bias_sensor}_RH, !- <none>
-      SET PTmp = "+name_cut(econ_choice)+"RETPressure1#{bias_sensor}_RH, !- <none>
+      SET RETTmp = "+name_cut(econ_choice)+"RETTemp1#{bias_sensor}_#{$faulttype}, !- <none>
+      SET RETHumRat = "+name_cut(econ_choice)+"RETOmega1#{bias_sensor}_#{$faulttype}, !- <none>
+      SET OATmp = "+name_cut(econ_choice)+"OATTemp1#{bias_sensor}_#{$faulttype}, !- <none>
+      SET OAHumRat = "+name_cut(econ_choice)+"OATOmega1#{bias_sensor}_#{$faulttype}, !- <none>
+      SET PTmp = "+name_cut(econ_choice)+"RETPressure1#{bias_sensor}_#{$faulttype}, !- <none>
       IF PTmp < DELTASMALL, !- <none>
       SET PTmp = 101325.0, !- Zero pressure during warmup may crash the code
       ENDIF, !- <none>
@@ -219,12 +219,12 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
     "
   end
   main_body = main_body+"
-      SET VDOT_DES = DesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_RH, !- <none>
-      SET CMDOT_D = CMDesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_RH, !- <none>
-      SET HMDOT_D = HMDesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_RH, !- <none>
+      SET VDOT_DES = DesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype}, !- <none>
+      SET CMDOT_D = CMDesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype}, !- <none>
+      SET HMDOT_D = HMDesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype}, !- <none>
       SET MDOT_DES = @Max CMDOT_D HMDOT_D, !- <none>
-      SET MDOT_OA_MIN = MinOAMdot"+name_cut(econ_choice)+"#{bias_sensor}_RH, !- <none>
-      SET MDOT_OA_MAX = MaxOAMdot"+name_cut(econ_choice)+"#{bias_sensor}_RH, !- <none>
+      SET MDOT_OA_MIN = MinOAMdot"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype}, !- <none>
+      SET MDOT_OA_MAX = MaxOAMdot"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype}, !- <none>
       IF VDOT_DES > SMALLVOLFLOW, !- <none>
       SET MIN_FRAC = MDOT_OA_MIN/MDOT_DES, !- no if statement for airloop existence because the code won't work without an airloop
       SET MIN_FLOW = MDOT_OA_MIN, !- <none>
@@ -236,7 +236,7 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
   
   if not controlleroutdoorair.getString(16).to_s.eql?("")  #Minimum Outdoor Air Schedule Name
     main_body = main_body+"
-      SET MIN_SCH_VALUE = "+name_cut(econ_choice)+"_MIN_SCH#{bias_sensor}_RH, !- <none>
+      SET MIN_SCH_VALUE = "+name_cut(econ_choice)+"_MIN_SCH#{bias_sensor}_#{$faulttype}, !- <none>
       SET MIN_SCH_VALUE = @MAX MIN_SCH_VALUE 0.00, !- <none>
       SET MIN_SCH_VALUE = @MIN MIN_SCH_VALUE 1.00, !- <none>
       SET MIN_FRAC = MIN_SCH_VALUE*MIN_FRAC, !- <none>
@@ -267,7 +267,7 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
               zone_name = name_cut(controllermechventilation.getString(4+3*i+1).to_s)
               if outdoorairspec.numFields == 7  #multiply the number with a schedule
                 main_body = main_body+"
-                  SET MECH_SCH = "+zone_name+"_OA_SCH#{bias_sensor}_RH, !- NEED A SENSOR FOR THE SCHEDULE
+                  SET MECH_SCH = "+zone_name+"_OA_SCH#{bias_sensor}_#{$faulttype}, !- NEED A SENSOR FOR THE SCHEDULE
                 "
               else
                 main_body = main_body+"
@@ -276,9 +276,9 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
               end
               if outdoorairspec.getString(1).to_s.eql?("Sum") #add code for summation
                 main_body = main_body+"
-                  SET ZONE_VOL = "+zone_name+"_VOL#{bias_sensor}_RH, !- NEED INTERNAL VARIABLE FOR ZONE VOLUME
-                  SET ZONE_MUL = "+zone_name+"_MUL#{bias_sensor}_RH, !- NEED INTERNAL VARIABLE FOR ZONE MULTIPLIER
-                  SET ZONE_LIST_MUL = "+zone_name+"_LIST_MUL#{bias_sensor}_RH, !- NEED INTERNAL VARIABLE FOR ZONE LIST MULTIPLIER
+                  SET ZONE_VOL = "+zone_name+"_VOL#{bias_sensor}_#{$faulttype}, !- NEED INTERNAL VARIABLE FOR ZONE VOLUME
+                  SET ZONE_MUL = "+zone_name+"_MUL#{bias_sensor}_#{$faulttype}, !- NEED INTERNAL VARIABLE FOR ZONE MULTIPLIER
+                  SET ZONE_LIST_MUL = "+zone_name+"_LIST_MUL#{bias_sensor}_#{$faulttype}, !- NEED INTERNAL VARIABLE FOR ZONE LIST MULTIPLIER
 				"
 				#####################################################
 				if peoples.empty?
@@ -303,7 +303,7 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
                   SET IND_OA = #{outdoorairspec.getString(2).to_s}, !- Zone occupant flow rate
                   SET IND_OA = IND_OA*ZONE_MUL*ZONE_LIST_MUL*ZONE_PPL, !- <none>
                   SET OA_MECH = OA_MECH+IND_OA*MECH_SCH, !- <none>
-                  SET ZONE_AREA = "+zone_name+"_AREA#{bias_sensor}_RH, !- NEED INTERNAL VARIABLE FOR ZONE FLOOR AREA
+                  SET ZONE_AREA = "+zone_name+"_AREA#{bias_sensor}_#{$faulttype}, !- NEED INTERNAL VARIABLE FOR ZONE FLOOR AREA
                   SET IND_OA = "+outdoorairspec.getString(3).to_s+"*ZONE_AREA, !- Zone floor area flow rate
                   SET IND_OA = IND_OA*ZONE_MUL*ZONE_LIST_MUL, !- <none>
                   SET OA_MECH = OA_MECH+IND_OA*MECH_SCH, !- <none>
@@ -317,14 +317,14 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
               else #add code for maximum
                 main_body = main_body+"
                   SET IND_OA_FIN = 0.0, !- For maximum calculation
-                  SET ZONE_VOL = "+zone_name+"_VOL#{bias_sensor}_RH, !- NEED INTERNAL VARIABLE FOR ZONE VOLUME
-                  SET ZONE_MUL = "+zone_name+"_MUL#{bias_sensor}_RH, !- NEED INTERNAL VARIABLE FOR ZONE MULTIPLIER
-                  SET ZONE_LIST_MUL = "+zone_name+"_LIST_MUL#{bias_sensor}_RH, !- NEED INTERNAL VARIABLE FOR ZONE LIST MULTIPLIER
-                  SET ZONE_PPL = "+zone_name+"_PEOPLE#{bias_sensor}_RH, !- NEED SENSOR FOR ZONE People Occupant Count
+                  SET ZONE_VOL = "+zone_name+"_VOL#{bias_sensor}_#{$faulttype}, !- NEED INTERNAL VARIABLE FOR ZONE VOLUME
+                  SET ZONE_MUL = "+zone_name+"_MUL#{bias_sensor}_#{$faulttype}, !- NEED INTERNAL VARIABLE FOR ZONE MULTIPLIER
+                  SET ZONE_LIST_MUL = "+zone_name+"_LIST_MUL#{bias_sensor}_#{$faulttype}, !- NEED INTERNAL VARIABLE FOR ZONE LIST MULTIPLIER
+                  SET ZONE_PPL = "+zone_name+"_PEOPLE#{bias_sensor}_#{$faulttype}, !- NEED SENSOR FOR ZONE People Occupant Count
                   SET IND_OA = #{outdoorairspec.getString(2).to_s}, !- Zone occupant flow rate
                   SET IND_OA = IND_OA*ZONE_MUL*ZONE_LIST_MUL*ZONE_PPL, !- <none>
                   SET IND_OA_FIN = @Max IND_OA_FIN IND_OA, !- <none>
-                  SET ZONE_AREA = "+zone_name+"_AREA#{bias_sensor}_RH, !- NEED INTERNAL VARIABLE FOR ZONE FLOOR AREA
+                  SET ZONE_AREA = "+zone_name+"_AREA#{bias_sensor}_#{$faulttype}, !- NEED INTERNAL VARIABLE FOR ZONE FLOOR AREA
                   SET IND_OA = "+outdoorairspec.getString(3).to_s+"*ZONE_AREA, !- Zone floor area flow rate
                   SET IND_OA = IND_OA*ZONE_MUL*ZONE_LIST_MUL, !- <none>
                   SET IND_OA_FIN = @Max IND_OA_FIN IND_OA, !- <none>
@@ -358,15 +358,15 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
     SET TDiff = RETTmp-OATmp, !- <none>
     SET TDiff = @Abs TDiff, !- <none>
     IF TDiff > DELTASMALL, !- <none>
-    SET OA_SIGN = (RETTmp-"+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_RH)/(RETTmp-OATmp), !- Initialize the signal
+    SET OA_SIGN = (RETTmp-"+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype})/(RETTmp-OATmp), !- Initialize the signal
     ELSE, !- <none>
-    IF RETTmp < "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_RH && RETTmp >= OATmp, !- <none>
+    IF RETTmp < "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype} && RETTmp >= OATmp, !- <none>
     SET OA_SIGN = -1, !- <none>
-    ELSEIF RETTmp < "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_RH && RETTmp < OATmp, !- <none>
+    ELSEIF RETTmp < "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype} && RETTmp < OATmp, !- <none>
     SET OA_SIGN = 1, !- <none>
-    ELSEIF RETTmp >= "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_RH && RETTmp >= OATmp,
+    ELSEIF RETTmp >= "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype} && RETTmp >= OATmp,
     SET OA_SIGN = 1, !- <none>
-    ELSEIF RETTmp >= "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_RH && RETTmp < OATmp,
+    ELSEIF RETTmp >= "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype} && RETTmp < OATmp,
     SET OA_SIGN = -1, !- <none>
     ENDIF, !- <none>
     ENDIF, !- <none>
@@ -406,7 +406,7 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
                   if branch.getString(ii).to_s.eql?(oas_name)
                     airsystem_name = branch.getString(0).to_s.gsub(" Supply Branch","").gsub(" Main Branch","")
                     main_body = main_body+"
-                      SET LOCKOUT_POS = "+name_cut(airsystem_name)+"_Htg#{bias_sensor}_RH, !- <none>
+                      SET LOCKOUT_POS = "+name_cut(airsystem_name)+"_Htg#{bias_sensor}_#{$faulttype}, !- <none>
                       IF LOCKOUT_POS > 0, !- <none>
                       SET NO_LOCK_OUT = False, !- <none>
                       ENDIF, !- <none>
@@ -415,7 +415,7 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
                       #check if there is a compressor on the loop
                       #if there is, add code to check if the economizer should be locked out
                       main_body = main_body+"
-                        SET LOCKOUT_POS = "+name_cut(airsystem_name)+"_Ctg#{bias_sensor}_RH, !- <none>
+                        SET LOCKOUT_POS = "+name_cut(airsystem_name)+"_Ctg#{bias_sensor}_#{$faulttype}, !- <none>
                         IF LOCKOUT_POS > 0, !- <none>
                         SET NO_LOCK_OUT = False, !- <none>
                         ENDIF, !- <none>
@@ -441,7 +441,7 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
       SET HIGHHUMCTRL = False, !- <none>
       ELSE, !- Running the economizer
       SET ECON_OP = True, !- <none>
-      IF OATmp > "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_RH, !- <none>
+      IF OATmp > "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype}, !- <none>
       SET OA_SIGN = 1, !- <none>
       ENDIF, !- <none>
     "
@@ -492,13 +492,13 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
     end
     if controlleroutdoorair.getString(21).to_s.eql?("Yes")  #High humidity control check
       main_body = main_body+"
-        IF ZoneHumidLOAD"+name_cut(econ_choice)+"#{bias_sensor}_RH < 0.0, !- High Humidity Control
+        IF ZoneHumidLOAD"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype} < 0.0, !- High Humidity Control
         SET HIGHHUMCTRL = True, !- <none>
         ENDIF, !- <none>
       "
       if controlleroutdoorair.getString(24).to_s.eql?("Yes")  #Control High Indoor Humidity Based on Outdoor Humidity Ratio
         main_body = main_body+"
-          IF ZoneHumid"+name_cut(econ_choice)+"#{bias_sensor}_RH <= OAHumRat, !- Control High Indoor Humidity Based on Outdoor Humidity Ratio
+          IF ZoneHumid"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype} <= OAHumRat, !- Control High Indoor Humidity Based on Outdoor Humidity Ratio
           SET HIGHHUMCTRL = False, !- Set it back to False
           ENDIF, !- <none>
         "
@@ -506,7 +506,7 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
     end
     if not controlleroutdoorair.getString(20).to_s.eql?("")  #Time of Day Economizer Control Schedule Name
       main_body = main_body+"
-        SET ECON_FLOW_SCH_VAL = ECONCTRL"+name_cut(econ_choice)+"_SCH#{bias_sensor}_RH, !- <none>
+        SET ECON_FLOW_SCH_VAL = ECONCTRL"+name_cut(econ_choice)+"_SCH#{bias_sensor}_#{$faulttype}, !- <none>
         IF ECON_FLOW_SCH_VAL > 0, !- <none>
         SET OA_SIGN = 1.0, !- <none>
         SET ECON_OP = True, !- <none>
@@ -536,17 +536,17 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
     IF NIGHTVENT == 0,
     IF OA_SIGN > MIN_FRAC,
     IF OA_SIGN < 1.0,
-    IF MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_RH > SMALLMASSFLOW, !- Check if the duct has airflow
-    SET RETENTH_GB#{econ_short_name}#{bias_sensor}_RH = ORI_RETENTH, !- to simulate feedback control, don't use measurement values
-    SET RETHUMRAT_GB#{econ_short_name}#{bias_sensor}_RH = ORI_RETHumRat, !- to simulate feedback control, don't use measurement values
-    SET OAENTH_GB#{econ_short_name}#{bias_sensor}_RH = ORI_OAENTH, !- to simulate feedback control, don't use measurement values
-    SET OAHUMRAT_GB#{econ_short_name}#{bias_sensor}_RH = ORI_OAHumRat, !- to simulate feedback control, don't use measurement values
-    SET LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_RH = MIN_FRAC, !- <none>
-    SET UPLIMIT_GB#{econ_short_name}#{bias_sensor}_RH = 1, !- <none>
-    SET MIXTEMPSET_GB#{econ_short_name}#{bias_sensor}_RH = "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_RH, !-<none>
-    RUN EMSSolveRegulaFalsi_OA_SIGN#{econ_short_name}#{bias_sensor}_RH, !- <none>
-    IF FLAG_GB#{econ_short_name}#{bias_sensor}_RH > 0, !- <none>
-    SET OA_SIGN = SOLN_GB#{econ_short_name}#{bias_sensor}_RH, !- <none>
+    IF MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} > SMALLMASSFLOW, !- Check if the duct has airflow
+    SET RETENTH_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = ORI_RETENTH, !- to simulate feedback control, don't use measurement values
+    SET RETHUMRAT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = ORI_RETHumRat, !- to simulate feedback control, don't use measurement values
+    SET OAENTH_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = ORI_OAENTH, !- to simulate feedback control, don't use measurement values
+    SET OAHUMRAT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = ORI_OAHumRat, !- to simulate feedback control, don't use measurement values
+    SET LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = MIN_FRAC, !- <none>
+    SET UPLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = 1, !- <none>
+    SET MIXTEMPSET_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype}, !-<none>
+    RUN EMSSolveRegulaFalsi_OA_SIGN#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+    IF FLAG_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} > 0, !- <none>
+    SET OA_SIGN = SOLN_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
     ENDIF,
     ENDIF,
     ENDIF,
@@ -566,10 +566,10 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
   if controlleroutdoorair.getString(21).to_s.eql?("Yes")  #High humidity control check
     main_body = main_body+"
       IF HIGHHUMCTRL == True, !- high humidity control
-      SET MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_RH = "+name_cut(econ_choice)+"MixAirFlow_CTRL#{bias_sensor}_RH, !- <none>
+      SET MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = "+name_cut(econ_choice)+"MixAirFlow_CTRL#{bias_sensor}_#{$faulttype}, !- <none>
       SET OA_SIGN_CAN = "+controlleroutdoorair.getString(23).to_s+", !- <none>
       SET OA_SIGN_CAN = OA_SIGN_CAN*MDOT_OA_MAX, !- <none>
-      SET OA_SIGN_CAN = OA_SIGN_CAN/MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_RH, !- <none>
+      SET OA_SIGN_CAN = OA_SIGN_CAN/MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
       SET OA_SIGN = @MAX OA_SIGN_CAN MIN_FRAC, !- <none>
       ENDIF,
     "
@@ -592,12 +592,12 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
   
   if not controlleroutdoorair.getString(17).to_s.eql?("")  #Minimum Fraction of Outdoor Air Schedule Name
     main_body = main_body+"
-      SET MIN_SCH_VALUE = "+name_cut(econ_choice)+"_MIN_FRAC_SCH#{bias_sensor}_RH, !- <none>
+      SET MIN_SCH_VALUE = "+name_cut(econ_choice)+"_MIN_FRAC_SCH#{bias_sensor}_#{$faulttype}, !- <none>
       SET MIN_SCH_VALUE = @Max MIN_SCH_VALUE 0.0, !- <none>
       SET MIN_SCH_VALUE = @Min MIN_SCH_VALUE 1.0, !- <none>
       IF MIN_SCH_VALUE > MIN_FRAC, !- <none>
       SET MIN_FRAC = MIN_SCH_VALUE, !- <none>
-      SET MDOT_OA_MIN = MIN_FRAC*MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_RH, !- <none>
+      SET MDOT_OA_MIN = MIN_FRAC*MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
       ENDIF, !- <none>
       SET OA_SIGN = @Max OA_SIGN MIN_FRAC, !- <none>
     "
@@ -605,12 +605,12 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
   
   if not controlleroutdoorair.getString(18).to_s.eql?("")  #Maximum Fraction of Outdoor Air Schedule Name
     main_body = main_body+"
-      SET MAX_SCH_VALUE = "+name_cut(econ_choice)+"_MAX_FRAC_SCH#{bias_sensor}_RH, !- <none>
+      SET MAX_SCH_VALUE = "+name_cut(econ_choice)+"_MAX_FRAC_SCH#{bias_sensor}_#{$faulttype}, !- <none>
       SET MAX_SCH_VALUE = @Max MAX_SCH_VALUE 0.0, !- <none>
       SET MAX_SCH_VALUE = @Min MAX_SCH_VALUE 1.0, !- <none>
       IF MIN_FRAC > MAX_SCH_VALUE, !- <none>
       SET MIN_FRAC = MAX_SCH_VALUE, !- <none>
-      SET MDOT_OA_MIN = MIN_FRAC*MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_RH, !- <none>
+      SET MDOT_OA_MIN = MIN_FRAC*MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
       ENDIF, !- <none>
       SET OA_SIGN = @Min OA_SIGN MAX_SCH_VALUE, !- <none>
     "
@@ -618,14 +618,14 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
   
   #calculate the outdoor airflow rate
   main_body = main_body+"
-    SET FinalFlow = OA_SIGN*MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_RH, !- <none>
+    SET FinalFlow = OA_SIGN*MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
   "
   
   #make sure that it doesn't exceed the limits of ventilation
   if not controlleroutdoorair.getString(19).to_s.eql?("")
     main_body = main_body+"
       IF OA_MECH > FinalFlow, !- <none>
-      SET FinalFlow = @Min OA_MECH MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_RH, !- <none>
+      SET FinalFlow = @Min OA_MECH MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
       ENDIF, !- <none>
     "
   end
@@ -636,7 +636,7 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
   if controlleroutdoorair.getString(15).to_s.eql?("FixedMinimum")
     main_body = main_body+"
       SET OA_NEW = FinalFlow, !- <none>
-      SET DUMMY = MinOAMdot"+name_cut(econ_choice)+"#{bias_sensor}_RH, !- Name too long
+      SET DUMMY = MinOAMdot"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype}, !- Name too long
       SET OA_NEW = @Max OA_NEW (DUMMY*MIN_SCH_VALUE), !- <none>
       SET FinalFlow = OA_NEW, !- <none>
     "
@@ -645,7 +645,7 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
   #check with mixed airflow
   main_body = main_body+"
     SET OA_NEW = FinalFlow, !- <none>
-    SET OA_NEW = @Min OA_NEW MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_RH, !- <none>
+    SET OA_NEW = @Min OA_NEW MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
     SET FinalFlow = OA_NEW, !- <none>
   "
   
@@ -661,7 +661,7 @@ def econ_rh_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoora
     SET OA_NEW = @Min MDOT_OA_MAX OA_NEW, !- <none>
     SET FinalFlow = OA_NEW, !- <none>
     ENDIF, !- <none>
-    SET "+name_cut(econ_choice)+"MDOT_OA#{bias_sensor}_RH = FinalFlow; !- <none>
+    SET "+name_cut(econ_choice)+"MDOT_OA#{bias_sensor}_#{$faulttype} = FinalFlow; !- <none>
   "
   
   return main_body
@@ -782,17 +782,17 @@ def econ_rh_sensor_bias_ems_other(string_objects, workspace, bias_sensor, contro
   
   string_objects << "
     EnergyManagementSystem:Subroutine,
-      RES_OA_SIGN#{econ_short_name}#{bias_sensor}_RH, !- Name
-      SET TEMP_OA_SIGN = OA_SIGN_GB#{econ_short_name}#{bias_sensor}_RH, !- <none>
-      SET TEMP_MIX_FLOW = MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_RH, !- <none>
+      RES_OA_SIGN#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- Name
+      SET TEMP_OA_SIGN = OA_SIGN_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      SET TEMP_MIX_FLOW = MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
       SET TEMP_OA_FLOW = TEMP_OA_SIGN*TEMP_MIX_FLOW, !- <none>
       SET RECFLOW1 = 0, !- <none>
       SET RECFLOW2 = TEMP_MIX_FLOW-TEMP_OA_FLOW, !- <none>
       SET RECIR_FLOW = @MAX RECFLOW1 RECFLOW2, !- <none>
-      SET TEMP_RETENTH = RETENTH_GB#{econ_short_name}#{bias_sensor}_RH, !- <none>
-      SET TEMP_RETHUMRAT = RETHUMRAT_GB#{econ_short_name}#{bias_sensor}_RH, !- <none>
-      SET TEMP_OAENTH = OAENTH_GB#{econ_short_name}#{bias_sensor}_RH, !- <none>
-      SET TEMP_OAHUMRAT = OAHUMRAT_GB#{econ_short_name}#{bias_sensor}_RH, !- <none>
+      SET TEMP_RETENTH = RETENTH_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      SET TEMP_RETHUMRAT = RETHUMRAT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      SET TEMP_OAENTH = OAENTH_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      SET TEMP_OAHUMRAT = OAHUMRAT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
       SET TEMP_MIXENTH = RECIR_FLOW*TEMP_RETENTH, !- <none>
       SET TEMP_MIXENTH = TEMP_MIXENTH+TEMP_OA_FLOW*TEMP_OAENTH, !- <none>
       SET TEMP_MIXENTH = TEMP_MIXENTH/TEMP_MIX_FLOW, !- <none>
@@ -800,23 +800,23 @@ def econ_rh_sensor_bias_ems_other(string_objects, workspace, bias_sensor, contro
       SET TEMP_MIXHUMRAT = TEMP_MIXHUMRAT+TEMP_OA_FLOW*TEMP_OAHUMRAT, !- <none>
       SET TEMP_MIXHUMRAT = TEMP_MIXHUMRAT/TEMP_MIX_FLOW, !- <none>
       SET TEMP_MIXTEMP = @TdbFnHW TEMP_MIXENTH TEMP_MIXHUMRAT, !- <none>
-      SET TEMP_AA = MIXTEMPSET_GB#{econ_short_name}#{bias_sensor}_RH-TEMP_MIXTEMP, !- <none>
-      SET RESIDUAL_GB#{econ_short_name}#{bias_sensor}_RH = TEMP_AA; !- <none>
+      SET TEMP_AA = MIXTEMPSET_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}-TEMP_MIXTEMP, !- <none>
+      SET RESIDUAL_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = TEMP_AA; !- <none>
   "
   
   string_objects << "
     EnergyManagementSystem:Subroutine,
-      EMSSolveRegulaFalsi_OA_SIGN#{econ_short_name}#{bias_sensor}_RH, !- Name
-      SET OA_SIGN_GB#{econ_short_name}#{bias_sensor}_RH = LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_RH, !- <none>
-      RUN RES_OA_SIGN#{econ_short_name}#{bias_sensor}_RH, !- <none>
-      SET Y0 = RESIDUAL_GB#{econ_short_name}#{bias_sensor}_RH, !- <none>
-      SET OA_SIGN_GB#{econ_short_name}#{bias_sensor}_RH = UPLIMIT_GB#{econ_short_name}#{bias_sensor}_RH, !- <none>
-      RUN RES_OA_SIGN#{econ_short_name}#{bias_sensor}_RH, !- <none>
-      SET Y1 = RESIDUAL_GB#{econ_short_name}#{bias_sensor}_RH, !- <none>
+      EMSSolveRegulaFalsi_OA_SIGN#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- Name
+      SET OA_SIGN_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      RUN RES_OA_SIGN#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      SET Y0 = RESIDUAL_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      SET OA_SIGN_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = UPLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      RUN RES_OA_SIGN#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      SET Y1 = RESIDUAL_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
       SET PROD = Y0*Y1, !- <none>
       IF Y0*Y1 > 0, !- <none>
-      SET FLAG_GB#{econ_short_name}#{bias_sensor}_RH = -2, !- <none>
-      SET SOLN_GB#{econ_short_name}#{bias_sensor}_RH = LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_RH, !- <none>
+      SET FLAG_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = -2, !- <none>
+      SET SOLN_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
       RETURN, ! Error for solution
       ENDIF, !- <none>
       SET CONT = 1, !- <none>
@@ -830,11 +830,11 @@ def econ_rh_sensor_bias_ems_other(string_objects, workspace, bias_sensor, contro
       SET DY = 1.d-10, !- <none>
       ENDIF, !- <none>
       ENDIF, !- <none>
-      SET XTemp = Y0*UPLIMIT_GB#{econ_short_name}#{bias_sensor}_RH, !- <none>
-      SET XTemp = (XTemp-Y1*LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_RH)/DY, !- <none>
-      SET OA_SIGN_GB#{econ_short_name}#{bias_sensor}_RH = XTemp, !- <none>
-      RUN RES_OA_SIGN#{econ_short_name}#{bias_sensor}_RH, !- <none>
-      SET YTemp = RESIDUAL_GB#{econ_short_name}#{bias_sensor}_RH, !- <none>
+      SET XTemp = Y0*UPLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      SET XTemp = (XTemp-Y1*LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype})/DY, !- <none>
+      SET OA_SIGN_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = XTemp, !- <none>
+      RUN RES_OA_SIGN#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      SET YTemp = RESIDUAL_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
       SET NITE = NITE+1, !- <none>
       IF YTemp < 0.0001 && YTemp+0.0001 > 0, !- <none>
       SET CONT = 0, !- <none>
@@ -845,101 +845,101 @@ def econ_rh_sensor_bias_ems_other(string_objects, workspace, bias_sensor, contro
       IF CONT > 0.0d0, !- <none>
       IF Y0 < 0.0d0, !- <none>
       IF YTemp < 0.0d0, !- <none>
-      SET LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_RH = XTemp, !- <none>
+      SET LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = XTemp, !- <none>
       SET Y0 = YTemp, !- <none>
       ELSE, !- <none>
-      SET UPLIMIT_GB#{econ_short_name}#{bias_sensor}_RH = XTemp, !- <none>
+      SET UPLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = XTemp, !- <none>
       SET Y1 = YTemp, !- <none>
       ENDIF, !- <none>
       ELSE, !- <none>
       IF YTemp < 0.0d0, !- <none>
-      SET UPLIMIT_GB#{econ_short_name}#{bias_sensor}_RH = XTemp, !- <none>
+      SET UPLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = XTemp, !- <none>
       SET Y1 = YTemp, !- <none>
       ELSE, !- <none>
-      SET LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_RH = XTemp, !- <none>
+      SET LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = XTemp, !- <none>
       SET Y0 = YTemp, !- <none>
       ENDIF, !- <none>
       ENDIF, !- <none>
       ENDIF, !- <none>
       ENDWHILE, !- <none>
       IF CONV == 1, !- <none>
-      SET FLAG_GB#{econ_short_name}#{bias_sensor}_RH = NITE, !- <none>
+      SET FLAG_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = NITE, !- <none>
       ELSE,
-      SET FLAG_GB#{econ_short_name}#{bias_sensor}_RH = -1, !- <none>
+      SET FLAG_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = -1, !- <none>
       ENDIF, !- <none>
-      SET SOLN_GB#{econ_short_name}#{bias_sensor}_RH = XTemp; !- <none>
+      SET SOLN_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = XTemp; !- <none>
   "
   
   string_objects << "
     EnergyManagementSystem:ProgramCallingManager,
       EMSCallRH_BIAS"+name_cut(econ_choice)+", !- Name
       InsideHVACSystemIterationLoop,       !- EnergyPlus Model Calling Point
-      RH_BIAS"+name_cut(econ_choice)+"#{bias_sensor}_RH, !- Name
+      RH_BIAS"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype}, !- Name
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      RESIDUAL_GB#{econ_short_name}#{bias_sensor}_RH;
+      RESIDUAL_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_RH;
+      LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      UPLIMIT_GB#{econ_short_name}#{bias_sensor}_RH;
+      UPLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      FLAG_GB#{econ_short_name}#{bias_sensor}_RH;
+      FLAG_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      SOLN_GB#{econ_short_name}#{bias_sensor}_RH;
+      SOLN_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      OA_SIGN_GB#{econ_short_name}#{bias_sensor}_RH;
+      OA_SIGN_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_RH;
+      MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      RETENTH_GB#{econ_short_name}#{bias_sensor}_RH;
+      RETENTH_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      RETHUMRAT_GB#{econ_short_name}#{bias_sensor}_RH;
+      RETHUMRAT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      OAENTH_GB#{econ_short_name}#{bias_sensor}_RH;
+      OAENTH_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      OAHUMRAT_GB#{econ_short_name}#{bias_sensor}_RH;
+      OAHUMRAT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      MIXTEMPSET_GB#{econ_short_name}#{bias_sensor}_RH;
+      MIXTEMPSET_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "   
     EnergyManagementSystem:Actuator,
-      "+name_cut(econ_choice)+"MDOT_OA#{bias_sensor}_RH,        !- Name
+      "+name_cut(econ_choice)+"MDOT_OA#{bias_sensor}_#{$faulttype},        !- Name
       "+econ_choice+", !- Actuated Component Unique Name
       Outdoor Air Controller,                                  !- Actuated Component Type
       Air Mass Flow Rate;                           !- Actuated Component Control Type
@@ -976,35 +976,35 @@ def econ_rh_sensor_bias_ems_other(string_objects, workspace, bias_sensor, contro
   
   string_objects << "
     EnergyManagementSystem:InternalVariable,
-      DesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_RH,
+      DesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype},
       "+airsystem_name+",
       Intermediate Air System Main Supply Volume Flow Rate;
   "
   
   string_objects << "
     EnergyManagementSystem:InternalVariable,
-      CMDesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_RH,
+      CMDesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype},
       "+airsystem_name+",
       Intermediate Air System "+sizing_option+" Peak Cooling Mass Flow Rate;
   "
   
   string_objects << "
     EnergyManagementSystem:InternalVariable,
-      HMDesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_RH,
+      HMDesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype},
       "+airsystem_name+",
       Intermediate Air System "+sizing_option+" Peak Heating Mass Flow Rate;
   "
   
   string_objects << "
     EnergyManagementSystem:InternalVariable,
-      MinOAMdot"+name_cut(econ_choice)+"#{bias_sensor}_RH,
+      MinOAMdot"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype},
       "+econ_choice+",
       Outdoor Air Controller Minimum Mass Flow Rate;
   "
   
   string_objects << "
     EnergyManagementSystem:InternalVariable,
-      MaxOAMdot"+name_cut(econ_choice)+"#{bias_sensor}_RH,
+      MaxOAMdot"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype},
       "+econ_choice+",
       Outdoor Air Controller Maximum Mass Flow Rate;
   "
@@ -1032,25 +1032,25 @@ def econ_rh_sensor_bias_ems_other(string_objects, workspace, bias_sensor, contro
               zone_name_tag = name_cut(zone_name)
               string_objects << "
                 EnergyManagementSystem:InternalVariable,
-                  "+zone_name_tag+"_VOL#{bias_sensor}_RH,
+                  "+zone_name_tag+"_VOL#{bias_sensor}_#{$faulttype},
                   "+zone_name+",
                   Zone Air Volume;
               "
               string_objects << "
                 EnergyManagementSystem:InternalVariable,
-                  "+zone_name_tag+"_MUL#{bias_sensor}_RH,
+                  "+zone_name_tag+"_MUL#{bias_sensor}_#{$faulttype},
                   "+zone_name+",
                   Zone Multiplier;
               "
               string_objects << "
                 EnergyManagementSystem:InternalVariable,
-                  "+zone_name_tag+"_LIST_MUL#{bias_sensor}_RH,
+                  "+zone_name_tag+"_LIST_MUL#{bias_sensor}_#{$faulttype},
                   "+zone_name+",
                   Zone List Multiplier;
               "
               string_objects << "
                 EnergyManagementSystem:InternalVariable,
-                  "+zone_name_tag+"_AREA#{bias_sensor}_RH,
+                  "+zone_name_tag+"_AREA#{bias_sensor}_#{$faulttype},
                   "+zone_name+",
                   Zone Floor Area;
               "
@@ -1069,7 +1069,7 @@ def econ_rh_sensor_bias_ems_other(string_objects, workspace, bias_sensor, contro
 			  #####################################################
               string_objects << "
                 EnergyManagementSystem:Sensor,
-                  "+zone_name_tag+"_OA_SCH#{bias_sensor}_RH, !- Name
+                  "+zone_name_tag+"_OA_SCH#{bias_sensor}_#{$faulttype}, !- Name
                   "+oaschedule_name+",                        !- Output:Variable or Output:Meter Index Key Name
                   Schedule Value;                !- Output:Variable or Output:Meter Name
               "
@@ -1082,14 +1082,14 @@ def econ_rh_sensor_bias_ems_other(string_objects, workspace, bias_sensor, contro
   
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(airsystem_name)+"_Htg#{bias_sensor}_RH,
+      "+name_cut(airsystem_name)+"_Htg#{bias_sensor}_#{$faulttype},
       "+airsystem_name+",
       Air System Heating Coil Total Heating Energy;
   "
   
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(airsystem_name)+"_Ctg#{bias_sensor}_RH,
+      "+name_cut(airsystem_name)+"_Ctg#{bias_sensor}_#{$faulttype},
       "+airsystem_name+",
       Air System Cooling Coil Total Cooling Energy;
   "
@@ -1097,21 +1097,21 @@ def econ_rh_sensor_bias_ems_other(string_objects, workspace, bias_sensor, contro
   ret_node_name = controlleroutdoorair.getString(2).to_s
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(econ_choice)+"RETTemp1#{bias_sensor}_RH,  !- Name
+      "+name_cut(econ_choice)+"RETTemp1#{bias_sensor}_#{$faulttype},  !- Name
       "+ret_node_name+",                        !- Output:Variable or Output:Meter Index Key Name
       System Node Temperature;                !- Output:Variable or Output:Meter Name
   "
   
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(econ_choice)+"RETOmega1#{bias_sensor}_RH,  !- Name
+      "+name_cut(econ_choice)+"RETOmega1#{bias_sensor}_#{$faulttype},  !- Name
       "+ret_node_name+",                        !- Output:Variable or Output:Meter Index Key Name
       System Node Humidity Ratio;                !- Output:Variable or Output:Meter Name
   "
   
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(econ_choice)+"RETPressure1#{bias_sensor}_RH,  !- Name
+      "+name_cut(econ_choice)+"RETPressure1#{bias_sensor}_#{$faulttype},  !- Name
       "+ret_node_name+",                        !- Output:Variable or Output:Meter Index Key Name
       System Node Pressure;                !- Output:Variable or Output:Meter Name
   "
@@ -1119,7 +1119,7 @@ def econ_rh_sensor_bias_ems_other(string_objects, workspace, bias_sensor, contro
   mx_node_name = controlleroutdoorair.getString(3).to_s
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_RH,  !- Name
+      "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype},  !- Name
       "+mx_node_name+",                        !- Output:Variable or Output:Meter Index Key Name
       System Node Setpoint Temperature;                !- Output:Variable or Output:Meter Name
   "
@@ -1127,21 +1127,21 @@ def econ_rh_sensor_bias_ems_other(string_objects, workspace, bias_sensor, contro
   oa_node_name = controlleroutdoorair.getString(4).to_s
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(econ_choice)+"OATTemp1#{bias_sensor}_RH,  !- Name
+      "+name_cut(econ_choice)+"OATTemp1#{bias_sensor}_#{$faulttype},  !- Name
       "+oa_node_name+",                        !- Output:Variable or Output:Meter Index Key Name
       System Node Temperature;                !- Output:Variable or Output:Meter Name
   "
   
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(econ_choice)+"OATOmega1#{bias_sensor}_RH,  !- Name
+      "+name_cut(econ_choice)+"OATOmega1#{bias_sensor}_#{$faulttype},  !- Name
       "+oa_node_name+",                        !- Output:Variable or Output:Meter Index Key Name
       System Node Humidity Ratio;                !- Output:Variable or Output:Meter Name
   "
   
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(econ_choice)+"MixAirFlow_CTRL#{bias_sensor}_RH,  !- Name
+      "+name_cut(econ_choice)+"MixAirFlow_CTRL#{bias_sensor}_#{$faulttype},  !- Name
       "+airsystem_name+",                        !- Output:Variable or Output:Meter Index Key Name
       Air System Mixed Air Mass Flow Rate;                !- Output:Variable or Output:Meter Name
   "
@@ -1152,7 +1152,7 @@ def econ_rh_sensor_bias_ems_other(string_objects, workspace, bias_sensor, contro
     # check high humidity control before adding
     string_objects << "
       EnergyManagementSystem:Sensor,
-        ZoneHumid"+name_cut(econ_choice)+"#{bias_sensor}_RH,  !- Name
+        ZoneHumid"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype},  !- Name
         "+humidistat_zone+",                        !- Output:Variable or Output:Meter Index Key Name
         Zone Air Humidity Ratio;                !- Output:Variable or Output:Meter Name
     "
@@ -1160,7 +1160,7 @@ def econ_rh_sensor_bias_ems_other(string_objects, workspace, bias_sensor, contro
     # check high humidity control before adding
     string_objects << "
       EnergyManagementSystem:Sensor,
-        ZoneHumidLOAD"+name_cut(econ_choice)+"#{bias_sensor}_RH,  !- Name
+        ZoneHumidLOAD"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype},  !- Name
         "+humidistat_zone+",                        !- Output:Variable or Output:Meter Index Key Name
         Zone Predicted Moisture Load to Humidifying Setpoint Moisture Transfer Rate;                !- Output:Variable or Output:Meter Name
     "
@@ -1170,7 +1170,7 @@ def econ_rh_sensor_bias_ems_other(string_objects, workspace, bias_sensor, contro
   if not controlleroutdoorair.getString(20).to_s.eql?("")
     string_objects << "
       EnergyManagementSystem:Sensor,
-        ECONCTRL"+name_cut(econ_choice)+"_SCH#{bias_sensor}_RH, !- Name
+        ECONCTRL"+name_cut(econ_choice)+"_SCH#{bias_sensor}_#{$faulttype}, !- Name
         "+controlleroutdoorair.getString(20).to_s+", !- Schedule Name
         Schedule Value; !- Output:Variable
     "
@@ -1180,7 +1180,7 @@ def econ_rh_sensor_bias_ems_other(string_objects, workspace, bias_sensor, contro
   if false
     string_objects << "
       EnergyManagementSystem:Sensor,
-        NIGHTVENT_SCH#{bias_sensor}_RH, !- Name
+        NIGHTVENT_SCH#{bias_sensor}_#{$faulttype}, !- Name
         [Schedule name from Ruby], !- Schedule Name
         Schedule Value; !- Output:Variable
     "
@@ -1190,7 +1190,7 @@ def econ_rh_sensor_bias_ems_other(string_objects, workspace, bias_sensor, contro
   if not controlleroutdoorair.getString(18).to_s.eql?("")
     string_objects << "
       EnergyManagementSystem:Sensor,
-        "+name_cut(econ_choice)+"_MAX_FRAC_SCH#{bias_sensor}_RH, !- Name
+        "+name_cut(econ_choice)+"_MAX_FRAC_SCH#{bias_sensor}_#{$faulttype}, !- Name
         "+controlleroutdoorair.getString(18).to_s+", !- Schedule Name
         Schedule Value; !- Output:Variable
     "
@@ -1200,7 +1200,7 @@ def econ_rh_sensor_bias_ems_other(string_objects, workspace, bias_sensor, contro
   if not controlleroutdoorair.getString(16).to_s.eql?("")
     string_objects << "
       EnergyManagementSystem:Sensor,
-        "+name_cut(econ_choice)+"_MIN_SCH#{bias_sensor}_RH, !- Name
+        "+name_cut(econ_choice)+"_MIN_SCH#{bias_sensor}_#{$faulttype}, !- Name
         "+controlleroutdoorair.getString(16).to_s+", !- Schedule Name
         Schedule Value; !- Output:Variable
     "
@@ -1210,7 +1210,7 @@ def econ_rh_sensor_bias_ems_other(string_objects, workspace, bias_sensor, contro
   if not controlleroutdoorair.getString(17).to_s.eql?("")
     string_objects << "
       EnergyManagementSystem:Sensor,
-        "+name_cut(econ_choice)+"_MIN_FRAC_SCH#{bias_sensor}_RH, !- Name
+        "+name_cut(econ_choice)+"_MIN_FRAC_SCH#{bias_sensor}_#{$faulttype}, !- Name
         "+controlleroutdoorair.getString(17).to_s+", !- Schedule Name
         Schedule Value; !- Output:Variable
     "

--- a/fault_measures_2017/BiasedEconomizerSensorReturnT/measure.xml
+++ b/fault_measures_2017/BiasedEconomizerSensorReturnT/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>biased_economizer_sensor_return_t</name>
   <uid>f1ba09fb-2903-45b2-838c-604b63fc4662</uid>
-  <version_id>38b58108-0ca0-4d49-9f8e-8c9cde68a957</version_id>
-  <version_modified>20190411T215034Z</version_modified>
+  <version_id>afceb73f-74e3-4949-8a48-46ff9a9a759b</version_id>
+  <version_modified>20190415T161742Z</version_modified>
   <xml_checksum>B7427881</xml_checksum>
   <class_name>BiasedEconomizerSensorReturnT</class_name>
   <display_name>Biased Economizer Sensor: Return Temperature</display_name>
@@ -131,7 +131,7 @@
       <filename>ControllerOutdoorAirFlow_T.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>1A6DF28C</checksum>
+      <checksum>E7FE2EC1</checksum>
     </file>
   </files>
 </measure>

--- a/fault_measures_2017/BiasedEconomizerSensorReturnT/measure.xml
+++ b/fault_measures_2017/BiasedEconomizerSensorReturnT/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>biased_economizer_sensor_return_t</name>
   <uid>f1ba09fb-2903-45b2-838c-604b63fc4662</uid>
-  <version_id>ed1afcfd-088c-4c07-a001-208ac1974d28</version_id>
-  <version_modified>20190410T223832Z</version_modified>
+  <version_id>6dfe6403-07d0-48f2-8d98-768dcfee9181</version_id>
+  <version_modified>20190411T203253Z</version_modified>
   <xml_checksum>B7427881</xml_checksum>
   <class_name>BiasedEconomizerSensorReturnT</class_name>
   <display_name>Biased Economizer Sensor: Return Temperature</display_name>
@@ -117,12 +117,6 @@
       <checksum>435C6B82</checksum>
     </file>
     <file>
-      <filename>ControllerOutdoorAirFlow_T.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>684A54B2</checksum>
-    </file>
-    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>1.5.0</identifier>
@@ -132,6 +126,12 @@
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
       <checksum>E02DB20A</checksum>
+    </file>
+    <file>
+      <filename>ControllerOutdoorAirFlow_T.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>3317723F</checksum>
     </file>
   </files>
 </measure>

--- a/fault_measures_2017/BiasedEconomizerSensorReturnT/measure.xml
+++ b/fault_measures_2017/BiasedEconomizerSensorReturnT/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>biased_economizer_sensor_return_t</name>
   <uid>f1ba09fb-2903-45b2-838c-604b63fc4662</uid>
-  <version_id>6dfe6403-07d0-48f2-8d98-768dcfee9181</version_id>
-  <version_modified>20190411T203253Z</version_modified>
+  <version_id>38b58108-0ca0-4d49-9f8e-8c9cde68a957</version_id>
+  <version_modified>20190411T215034Z</version_modified>
   <xml_checksum>B7427881</xml_checksum>
   <class_name>BiasedEconomizerSensorReturnT</class_name>
   <display_name>Biased Economizer Sensor: Return Temperature</display_name>
@@ -131,7 +131,7 @@
       <filename>ControllerOutdoorAirFlow_T.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>3317723F</checksum>
+      <checksum>1A6DF28C</checksum>
     </file>
   </files>
 </measure>

--- a/fault_measures_2017/BiasedEconomizerSensorReturnT/resources/ControllerOutdoorAirFlow_T.rb
+++ b/fault_measures_2017/BiasedEconomizerSensorReturnT/resources/ControllerOutdoorAirFlow_T.rb
@@ -8,7 +8,6 @@ require_relative 'misc_eplus_func'
 def faultintensity_adjustmentfactor(string_objects, time_constant, time_step, start_month, start_date, start_time, end_month, end_date, end_time, oacontrollername)
 
   #append transient fault adjustment factor
-  ##################################################
   string_objects << "
     EnergyManagementSystem:Program,
       AF_P_#{$faulttype}_#{oacontrollername},                    !- Name
@@ -108,7 +107,6 @@ def faultintensity_adjustmentfactor(string_objects, time_constant, time_step, st
       AfterPredictorAfterHVACManagers,  !- EnergyPlus Model Calling Point
       AF_P_#{$faulttype}_#{oacontrollername};                    !- Program Name 1
   "
-  ##################################################
   
   return string_objects
   
@@ -136,15 +134,15 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
   econ_short_name = name_cut(econ_choice)
   main_body = "
     EnergyManagementSystem:Program,
-      t_bias"+name_cut(econ_choice)+"#{bias_sensor}_T, !- Name
+      t_bias"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype}, !- Name
       SET DELTASMALL = 0.00001, !- Program Line 1
       SET SMALLMASSFLOW = 0.001, !- Program Line 2
       SET SMALLVOLFLOW = 0.001, !- Program Line 3
       SET HIGHHUMCTRL = False, !- <none>
       SET NIGHTVENT = False, !- <none>
       SET ECON_OP = True, !- <none>
-      SET MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_T = "+name_cut(econ_choice)+"MixAirFlow_CTRL#{bias_sensor}_T, !- <none>
-      IF MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_T < SMALLMASSFLOW, !- Check if the duct has airflow
+      SET MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = "+name_cut(econ_choice)+"MixAirFlow_CTRL#{bias_sensor}_#{$faulttype}, !- <none>
+      IF MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} < SMALLMASSFLOW, !- Check if the duct has airflow
       SET FinalFlow = 0.00, !- <none>
       RETURN, !- <none>
       ENDIF, !- <none>
@@ -161,11 +159,11 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
   end
   if bias_sensor.eql?("RET")
     main_body = main_body+"
-      SET RETTmp = "+name_cut(econ_choice)+"RETTemp1#{bias_sensor}_T"+ret_str_num+"*AF_current_#{$faulttype}_#{oacontrollername}, !- <none>
-      SET RETHumRat = "+name_cut(econ_choice)+"RETOmega1#{bias_sensor}_T, !- <none>
-      SET OATmp = "+name_cut(econ_choice)+"OATTemp1#{bias_sensor}_T, !- <none>
-      SET OAHumRat = "+name_cut(econ_choice)+"OATOmega1#{bias_sensor}_T, !- <none>
-      SET PTmp = "+name_cut(econ_choice)+"RETPressure1#{bias_sensor}_T, !- <none>
+      SET RETTmp = "+name_cut(econ_choice)+"RETTemp1#{bias_sensor}_#{$faulttype}"+ret_str_num+"*AF_current_#{$faulttype}_#{oacontrollername}, !- <none>
+      SET RETHumRat = "+name_cut(econ_choice)+"RETOmega1#{bias_sensor}_#{$faulttype}, !- <none>
+      SET OATmp = "+name_cut(econ_choice)+"OATTemp1#{bias_sensor}_#{$faulttype}, !- <none>
+      SET OAHumRat = "+name_cut(econ_choice)+"OATOmega1#{bias_sensor}_#{$faulttype}, !- <none>
+      SET PTmp = "+name_cut(econ_choice)+"RETPressure1#{bias_sensor}_#{$faulttype}, !- <none>
       IF PTmp < DELTASMALL, !- <none>
       SET PTmp = 101325.0, !- Zero pressure during warmup may crash the code
       ENDIF, !- <none>
@@ -181,11 +179,11 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
     "
   elsif bias_sensor.eql?("OA")
     main_body = main_body+"
-	  SET RETTmp = "+name_cut(econ_choice)+"RETTemp1#{bias_sensor}_T, !- <none>
-      SET RETHumRat = "+name_cut(econ_choice)+"RETOmega1#{bias_sensor}_T, !- <none>
-      SET OATmp = "+name_cut(econ_choice)+"OATTemp1#{bias_sensor}_T"+oa_str_num+"*AF_current_#{$faulttype}_#{oacontrollername}, !- <none>
-      SET OAHumRat = "+name_cut(econ_choice)+"OATOmega1#{bias_sensor}_T, !- <none>
-      SET PTmp = "+name_cut(econ_choice)+"RETPressure1#{bias_sensor}_T, !- <none>
+	  SET RETTmp = "+name_cut(econ_choice)+"RETTemp1#{bias_sensor}_#{$faulttype}, !- <none>
+      SET RETHumRat = "+name_cut(econ_choice)+"RETOmega1#{bias_sensor}_#{$faulttype}, !- <none>
+      SET OATmp = "+name_cut(econ_choice)+"OATTemp1#{bias_sensor}_#{$faulttype}"+oa_str_num+"*AF_current_#{$faulttype}_#{oacontrollername}, !- <none>
+      SET OAHumRat = "+name_cut(econ_choice)+"OATOmega1#{bias_sensor}_#{$faulttype}, !- <none>
+      SET PTmp = "+name_cut(econ_choice)+"RETPressure1#{bias_sensor}_#{$faulttype}, !- <none>
       IF PTmp < DELTASMALL, !- <none>
       SET PTmp = 101325.0, !- Zero pressure during warmup may crash the code
       ENDIF, !- <none>
@@ -202,11 +200,11 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
     "
   else  #for bias in both sensors
     main_body = main_body+"
-      SET RETTmp = "+name_cut(econ_choice)+"RETTemp1#{bias_sensor}_T"+ret_str_num+"*AF_current_#{$faulttype}_#{oacontrollername}, !- <none>
-      SET RETHumRat = "+name_cut(econ_choice)+"RETOmega1#{bias_sensor}_T, !- <none>
-      SET OATmp = "+name_cut(econ_choice)+"OATTemp1#{bias_sensor}_T"+oa_str_num+"*AF_current_#{$faulttype}_#{oacontrollername}, !- <none>
-      SET OAHumRat = "+name_cut(econ_choice)+"OATOmega1#{bias_sensor}_T, !- <none>
-      SET PTmp = "+name_cut(econ_choice)+"RETPressure1#{bias_sensor}_T, !- <none>
+      SET RETTmp = "+name_cut(econ_choice)+"RETTemp1#{bias_sensor}_#{$faulttype}"+ret_str_num+"*AF_current_#{$faulttype}_#{oacontrollername}, !- <none>
+      SET RETHumRat = "+name_cut(econ_choice)+"RETOmega1#{bias_sensor}_#{$faulttype}, !- <none>
+      SET OATmp = "+name_cut(econ_choice)+"OATTemp1#{bias_sensor}_#{$faulttype}"+oa_str_num+"*AF_current_#{$faulttype}_#{oacontrollername}, !- <none>
+      SET OAHumRat = "+name_cut(econ_choice)+"OATOmega1#{bias_sensor}_#{$faulttype}, !- <none>
+      SET PTmp = "+name_cut(econ_choice)+"RETPressure1#{bias_sensor}_#{$faulttype}, !- <none>
       IF PTmp < DELTASMALL, !- <none>
       SET PTmp = 101325.0, !- Zero pressure during warmup may crash the code
       ENDIF, !- <none>
@@ -224,12 +222,12 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
     "
   end
   main_body = main_body+"
-      SET VDOT_DES = DesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_T, !- <none>
-      SET CMDOT_D = CMDesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_T, !- <none>
-      SET HMDOT_D = HMDesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_T, !- <none>
+      SET VDOT_DES = DesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype}, !- <none>
+      SET CMDOT_D = CMDesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype}, !- <none>
+      SET HMDOT_D = HMDesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype}, !- <none>
       SET MDOT_DES = @Max CMDOT_D HMDOT_D, !- <none>
-      SET MDOT_OA_MIN = MinOAMdot"+name_cut(econ_choice)+"#{bias_sensor}_T, !- <none>
-      SET MDOT_OA_MAX = MaxOAMdot"+name_cut(econ_choice)+"#{bias_sensor}_T, !- <none>
+      SET MDOT_OA_MIN = MinOAMdot"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype}, !- <none>
+      SET MDOT_OA_MAX = MaxOAMdot"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype}, !- <none>
       IF VDOT_DES > SMALLVOLFLOW, !- <none>
       SET MIN_FRAC = MDOT_OA_MIN/MDOT_DES, !- no if statement for airloop existence because the code won't work without an airloop
       SET MIN_FLOW = MDOT_OA_MIN, !- <none>
@@ -241,7 +239,7 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
   
   if not controlleroutdoorair.getString(16).to_s.eql?("")  #Minimum Outdoor Air Schedule Name
     main_body = main_body+"
-      SET MIN_SCH_VALUE = "+name_cut(econ_choice)+"_MIN_SCH#{bias_sensor}_T, !- <none>
+      SET MIN_SCH_VALUE = "+name_cut(econ_choice)+"_MIN_SCH#{bias_sensor}_#{$faulttype}, !- <none>
       SET MIN_SCH_VALUE = @MAX MIN_SCH_VALUE 0.00, !- <none>
       SET MIN_SCH_VALUE = @MIN MIN_SCH_VALUE 1.00, !- <none>
       SET MIN_FRAC = MIN_SCH_VALUE*MIN_FRAC, !- <none>
@@ -268,11 +266,10 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
         for i in 0..vent_num_zone-1  #for each zone
           outdoorairspecs.each do |outdoorairspec|
             if controllermechventilation.getString(4+3*i+2).to_s.eql?(outdoorairspec.getString(0).to_s)
-              # zone_name = name_cut(outdoorairspec.getString(0).to_s)
               zone_name = name_cut(controllermechventilation.getString(4+3*i+1).to_s)
               if outdoorairspec.numFields == 7  #multiply the number with a schedule
                 main_body = main_body+"
-                  SET MECH_SCH = "+zone_name+"_OA_SCH#{bias_sensor}_T, !- NEED A SENSOR FOR THE SCHEDULE
+                  SET MECH_SCH = "+zone_name+"_OA_SCH#{bias_sensor}_#{$faulttype}, !- NEED A SENSOR FOR THE SCHEDULE
                 "
               else
                 main_body = main_body+"
@@ -281,9 +278,9 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
               end
               if outdoorairspec.getString(1).to_s.eql?("Sum") #add code for summation
                 main_body = main_body+"
-                  SET ZONE_VOL = "+zone_name+"_VOL#{bias_sensor}_T, !- NEED INTERNAL VARIABLE FOR ZONE VOLUME
-                  SET ZONE_MUL = "+zone_name+"_MUL#{bias_sensor}_T, !- NEED INTERNAL VARIABLE FOR ZONE MULTIPLIER
-                  SET ZONE_LIST_MUL = "+zone_name+"_LIST_MUL#{bias_sensor}_T, !- NEED INTERNAL VARIABLE FOR ZONE LIST MULTIPLIER
+                  SET ZONE_VOL = "+zone_name+"_VOL#{bias_sensor}_#{$faulttype}, !- NEED INTERNAL VARIABLE FOR ZONE VOLUME
+                  SET ZONE_MUL = "+zone_name+"_MUL#{bias_sensor}_#{$faulttype}, !- NEED INTERNAL VARIABLE FOR ZONE MULTIPLIER
+                  SET ZONE_LIST_MUL = "+zone_name+"_LIST_MUL#{bias_sensor}_#{$faulttype}, !- NEED INTERNAL VARIABLE FOR ZONE LIST MULTIPLIER
 				"
 				#####################################################
 				if peoples.empty?
@@ -294,7 +291,7 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
 				  peoples.each do |people|
 			        if people.getString(1).to_s.eql?(controllermechventilation.getString(4+3*i+1).to_s)
 				      main_body = main_body+"
-                        SET ZONE_PPL = "+zone_name+"_PEOPLE#{bias_sensor}_T, !- NEED SENSOR FOR ZONE People Occupant Count
+                        SET ZONE_PPL = "+zone_name+"_PEOPLE#{bias_sensor}_#{$faulttype}, !- NEED SENSOR FOR ZONE People Occupant Count
 				      "
 				    else
 				      main_body = main_body+"
@@ -308,7 +305,7 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
                   SET IND_OA = #{outdoorairspec.getString(2).to_s}, !- Zone occupant flow rate
                   SET IND_OA = IND_OA*ZONE_MUL*ZONE_LIST_MUL*ZONE_PPL, !- <none>
                   SET OA_MECH = OA_MECH+IND_OA*MECH_SCH, !- <none>
-                  SET ZONE_AREA = "+zone_name+"_AREA#{bias_sensor}_T, !- NEED INTERNAL VARIABLE FOR ZONE FLOOR AREA
+                  SET ZONE_AREA = "+zone_name+"_AREA#{bias_sensor}_#{$faulttype}, !- NEED INTERNAL VARIABLE FOR ZONE FLOOR AREA
                   SET IND_OA = "+outdoorairspec.getString(3).to_s+"*ZONE_AREA, !- Zone floor area flow rate
                   SET IND_OA = IND_OA*ZONE_MUL*ZONE_LIST_MUL, !- <none>
                   SET OA_MECH = OA_MECH+IND_OA*MECH_SCH, !- <none>
@@ -322,14 +319,14 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
               else #add code for maximum
                 main_body = main_body+"
                   SET IND_OA_FIN = 0.0, !- For maximum calculation
-                  SET ZONE_VOL = "+zone_name+"_VOL#{bias_sensor}_T, !- NEED INTERNAL VARIABLE FOR ZONE VOLUME
-                  SET ZONE_MUL = "+zone_name+"_MUL#{bias_sensor}_T, !- NEED INTERNAL VARIABLE FOR ZONE MULTIPLIER
-                  SET ZONE_LIST_MUL = "+zone_name+"_LIST_MUL#{bias_sensor}_T, !- NEED INTERNAL VARIABLE FOR ZONE LIST MULTIPLIER
-                  SET ZONE_PPL = "+zone_name+"_PEOPLE#{bias_sensor}_T, !- NEED SENSOR FOR ZONE People Occupant Count
+                  SET ZONE_VOL = "+zone_name+"_VOL#{bias_sensor}_#{$faulttype}, !- NEED INTERNAL VARIABLE FOR ZONE VOLUME
+                  SET ZONE_MUL = "+zone_name+"_MUL#{bias_sensor}_#{$faulttype}, !- NEED INTERNAL VARIABLE FOR ZONE MULTIPLIER
+                  SET ZONE_LIST_MUL = "+zone_name+"_LIST_MUL#{bias_sensor}_#{$faulttype}, !- NEED INTERNAL VARIABLE FOR ZONE LIST MULTIPLIER
+                  SET ZONE_PPL = "+zone_name+"_PEOPLE#{bias_sensor}_#{$faulttype}, !- NEED SENSOR FOR ZONE People Occupant Count
                   SET IND_OA = #{outdoorairspec.getString(2).to_s}, !- Zone occupant flow rate
                   SET IND_OA = IND_OA*ZONE_MUL*ZONE_LIST_MUL*ZONE_PPL, !- <none>
                   SET IND_OA_FIN = @Max IND_OA_FIN IND_OA, !- <none>
-                  SET ZONE_AREA = "+zone_name+"_AREA#{bias_sensor}_T, !- NEED INTERNAL VARIABLE FOR ZONE FLOOR AREA
+                  SET ZONE_AREA = "+zone_name+"_AREA#{bias_sensor}_#{$faulttype}, !- NEED INTERNAL VARIABLE FOR ZONE FLOOR AREA
                   SET IND_OA = "+outdoorairspec.getString(3).to_s+"*ZONE_AREA, !- Zone floor area flow rate
                   SET IND_OA = IND_OA*ZONE_MUL*ZONE_LIST_MUL, !- <none>
                   SET IND_OA_FIN = @Max IND_OA_FIN IND_OA, !- <none>
@@ -363,15 +360,15 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
     SET TDiff = RETTmp-OATmp, !- <none>
     SET TDiff = @Abs TDiff, !- <none>
     IF TDiff > DELTASMALL, !- <none>
-    SET OA_SIGN = (RETTmp-"+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_T)/(RETTmp-OATmp), !- Initialize the signal
+    SET OA_SIGN = (RETTmp-"+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype})/(RETTmp-OATmp), !- Initialize the signal
     ELSE, !- <none>
-    IF RETTmp < "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_T && RETTmp >= OATmp, !- <none>
+    IF RETTmp < "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype} && RETTmp >= OATmp, !- <none>
     SET OA_SIGN = -1, !- <none>
-    ELSEIF RETTmp < "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_T && RETTmp < OATmp, !- <none>
+    ELSEIF RETTmp < "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype} && RETTmp < OATmp, !- <none>
     SET OA_SIGN = 1, !- <none>
-    ELSEIF RETTmp >= "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_T && RETTmp >= OATmp,
+    ELSEIF RETTmp >= "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype} && RETTmp >= OATmp,
     SET OA_SIGN = 1, !- <none>
-    ELSEIF RETTmp >= "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_T && RETTmp < OATmp,
+    ELSEIF RETTmp >= "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype} && RETTmp < OATmp,
     SET OA_SIGN = -1, !- <none>
     ENDIF, !- <none>
     ENDIF, !- <none>
@@ -411,7 +408,7 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
                   if branch.getString(ii).to_s.eql?(oas_name)
                     airsystem_name = branch.getString(0).to_s.gsub(" Supply Branch","").gsub(" Main Branch","")
                     main_body = main_body+"
-                      SET LOCKOUT_POS = "+name_cut(airsystem_name)+"_Htg#{bias_sensor}_T, !- <none>
+                      SET LOCKOUT_POS = "+name_cut(airsystem_name)+"_Htg#{bias_sensor}_#{$faulttype}, !- <none>
                       IF LOCKOUT_POS > 0, !- <none>
                       SET NO_LOCK_OUT = False, !- <none>
                       ENDIF, !- <none>
@@ -420,7 +417,7 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
                       #check if there is a compressor on the loop
                       #if there is, add code to check if the economizer should be locked out
                       main_body = main_body+"
-                        SET LOCKOUT_POS = "+name_cut(airsystem_name)+"_Ctg#{bias_sensor}_T, !- <none>
+                        SET LOCKOUT_POS = "+name_cut(airsystem_name)+"_Ctg#{bias_sensor}_#{$faulttype}, !- <none>
                         IF LOCKOUT_POS > 0, !- <none>
                         SET NO_LOCK_OUT = False, !- <none>
                         ENDIF, !- <none>
@@ -446,7 +443,7 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
       SET HIGHHUMCTRL = False, !- <none>
       ELSE, !- Running the economizer
       SET ECON_OP = True, !- <none>
-      IF OATmp > "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_T, !- <none>
+      IF OATmp > "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype}, !- <none>
       SET OA_SIGN = 1, !- <none>
       ENDIF, !- <none>
     "
@@ -497,13 +494,13 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
     end
     if controlleroutdoorair.getString(21).to_s.eql?("Yes")  #High humidity control check
       main_body = main_body+"
-        IF ZoneHumidLOAD"+name_cut(econ_choice)+"#{bias_sensor}_T < 0.0, !- High Humidity Control
+        IF ZoneHumidLOAD"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype} < 0.0, !- High Humidity Control
         SET HIGHHUMCTRL = True, !- <none>
         ENDIF, !- <none>
       "
       if controlleroutdoorair.getString(24).to_s.eql?("Yes")  #Control High Indoor Humidity Based on Outdoor Humidity Ratio
         main_body = main_body+"
-          IF ZoneHumid"+name_cut(econ_choice)+"#{bias_sensor}_T <= OAHumRat, !- Control High Indoor Humidity Based on Outdoor Humidity Ratio
+          IF ZoneHumid"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype} <= OAHumRat, !- Control High Indoor Humidity Based on Outdoor Humidity Ratio
           SET HIGHHUMCTRL = False, !- Set it back to False
           ENDIF, !- <none>
         "
@@ -511,7 +508,7 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
     end
     if not controlleroutdoorair.getString(20).to_s.eql?("")  #Time of Day Economizer Control Schedule Name
       main_body = main_body+"
-        SET ECON_FLOW_SCH_VAL = ECONCTRL"+name_cut(econ_choice)+"_SCH#{bias_sensor}_T, !- <none>
+        SET ECON_FLOW_SCH_VAL = ECONCTRL"+name_cut(econ_choice)+"_SCH#{bias_sensor}_#{$faulttype}, !- <none>
         IF ECON_FLOW_SCH_VAL > 0, !- <none>
         SET OA_SIGN = 1.0, !- <none>
         SET ECON_OP = True, !- <none>
@@ -541,17 +538,17 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
     IF NIGHTVENT == 0,
     IF OA_SIGN > MIN_FRAC,
     IF OA_SIGN < 1.0,
-    IF MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_T > SMALLMASSFLOW, !- Check if the duct has airflow
-    SET RETENTH_GB#{econ_short_name}#{bias_sensor}_T = ORI_RETENTH, !- to simulate feedback control, don't use measurement values
-    SET RETHUMRAT_GB#{econ_short_name}#{bias_sensor}_T = ORI_RETHumRat, !- to simulate feedback control, don't use measurement values
-    SET OAENTH_GB#{econ_short_name}#{bias_sensor}_T = ORI_OAENTH, !- to simulate feedback control, don't use measurement values
-    SET OAHUMRAT_GB#{econ_short_name}#{bias_sensor}_T = ORI_OAHumRat, !- to simulate feedback control, don't use measurement values
-    SET LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_T = MIN_FRAC, !- <none>
-    SET UPLIMIT_GB#{econ_short_name}#{bias_sensor}_T = 1, !- <none>
-    SET MIXTEMPSET_GB#{econ_short_name}#{bias_sensor}_T = "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_T, !-<none>
-    RUN EMSSolveRegulaFalsi_OA_SIGN#{econ_short_name}#{bias_sensor}_T, !- <none>
-    IF FLAG_GB#{econ_short_name}#{bias_sensor}_T > 0, !- <none>
-    SET OA_SIGN = SOLN_GB#{econ_short_name}#{bias_sensor}_T, !- <none>
+    IF MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} > SMALLMASSFLOW, !- Check if the duct has airflow
+    SET RETENTH_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = ORI_RETENTH, !- to simulate feedback control, don't use measurement values
+    SET RETHUMRAT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = ORI_RETHumRat, !- to simulate feedback control, don't use measurement values
+    SET OAENTH_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = ORI_OAENTH, !- to simulate feedback control, don't use measurement values
+    SET OAHUMRAT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = ORI_OAHumRat, !- to simulate feedback control, don't use measurement values
+    SET LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = MIN_FRAC, !- <none>
+    SET UPLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = 1, !- <none>
+    SET MIXTEMPSET_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype}, !-<none>
+    RUN EMSSolveRegulaFalsi_OA_SIGN#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+    IF FLAG_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} > 0, !- <none>
+    SET OA_SIGN = SOLN_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
     ENDIF,
     ENDIF,
     ENDIF,
@@ -571,10 +568,10 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
   if controlleroutdoorair.getString(21).to_s.eql?("Yes")  #High humidity control check
     main_body = main_body+"
       IF HIGHHUMCTRL == True, !- high humidity control
-      SET MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_T = "+name_cut(econ_choice)+"MixAirFlow_CTRL#{bias_sensor}_T, !- <none>
+      SET MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = "+name_cut(econ_choice)+"MixAirFlow_CTRL#{bias_sensor}_#{$faulttype}, !- <none>
       SET OA_SIGN_CAN = "+controlleroutdoorair.getString(23).to_s+", !- <none>
       SET OA_SIGN_CAN = OA_SIGN_CAN*MDOT_OA_MAX, !- <none>
-      SET OA_SIGN_CAN = OA_SIGN_CAN/MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_T, !- <none>
+      SET OA_SIGN_CAN = OA_SIGN_CAN/MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
       SET OA_SIGN = @MAX OA_SIGN_CAN MIN_FRAC, !- <none>
       ENDIF,
     "
@@ -597,12 +594,12 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
   
   if not controlleroutdoorair.getString(17).to_s.eql?("")  #Minimum Fraction of Outdoor Air Schedule Name
     main_body = main_body+"
-      SET MIN_SCH_VALUE = "+name_cut(econ_choice)+"_MIN_FRAC_SCH#{bias_sensor}_T, !- <none>
+      SET MIN_SCH_VALUE = "+name_cut(econ_choice)+"_MIN_FRAC_SCH#{bias_sensor}_#{$faulttype}, !- <none>
       SET MIN_SCH_VALUE = @Max MIN_SCH_VALUE 0.0, !- <none>
       SET MIN_SCH_VALUE = @Min MIN_SCH_VALUE 1.0, !- <none>
       IF MIN_SCH_VALUE > MIN_FRAC, !- <none>
       SET MIN_FRAC = MIN_SCH_VALUE, !- <none>
-      SET MDOT_OA_MIN = MIN_FRAC*MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_T, !- <none>
+      SET MDOT_OA_MIN = MIN_FRAC*MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
       ENDIF, !- <none>
       SET OA_SIGN = @Max OA_SIGN MIN_FRAC, !- <none>
     "
@@ -610,12 +607,12 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
   
   if not controlleroutdoorair.getString(18).to_s.eql?("")  #Maximum Fraction of Outdoor Air Schedule Name
     main_body = main_body+"
-      SET MAX_SCH_VALUE = "+name_cut(econ_choice)+"_MAX_FRAC_SCH#{bias_sensor}_T, !- <none>
+      SET MAX_SCH_VALUE = "+name_cut(econ_choice)+"_MAX_FRAC_SCH#{bias_sensor}_#{$faulttype}, !- <none>
       SET MAX_SCH_VALUE = @Max MAX_SCH_VALUE 0.0, !- <none>
       SET MAX_SCH_VALUE = @Min MAX_SCH_VALUE 1.0, !- <none>
       IF MIN_FRAC > MAX_SCH_VALUE, !- <none>
       SET MIN_FRAC = MAX_SCH_VALUE, !- <none>
-      SET MDOT_OA_MIN = MIN_FRAC*MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_T, !- <none>
+      SET MDOT_OA_MIN = MIN_FRAC*MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
       ENDIF, !- <none>
       SET OA_SIGN = @Min OA_SIGN MAX_SCH_VALUE, !- <none>
     "
@@ -623,14 +620,14 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
   
   #calculate the outdoor airflow rate
   main_body = main_body+"
-    SET FinalFlow = OA_SIGN*MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_T, !- <none>
+    SET FinalFlow = OA_SIGN*MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
   "
   
   #make sure that it doesn't exceed the limits of ventilation
   if not controlleroutdoorair.getString(19).to_s.eql?("")
     main_body = main_body+"
       IF OA_MECH > FinalFlow, !- <none>
-      SET FinalFlow = @Min OA_MECH MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_T, !- <none>
+      SET FinalFlow = @Min OA_MECH MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
       ENDIF, !- <none>
     "
   end
@@ -641,7 +638,7 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
   if controlleroutdoorair.getString(15).to_s.eql?("FixedMinimum")
     main_body = main_body+"
       SET OA_NEW = FinalFlow, !- <none>
-      SET DUMMY = MinOAMdot"+name_cut(econ_choice)+"#{bias_sensor}_T, !- Name too long
+      SET DUMMY = MinOAMdot"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype}, !- Name too long
       SET OA_NEW = @Max OA_NEW (DUMMY*MIN_SCH_VALUE), !- <none>
       SET FinalFlow = OA_NEW, !- <none>
     "
@@ -650,7 +647,7 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
   #check with mixed airflow
   main_body = main_body+"
     SET OA_NEW = FinalFlow, !- <none>
-    SET OA_NEW = @Min OA_NEW MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_T, !- <none>
+    SET OA_NEW = @Min OA_NEW MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
     SET FinalFlow = OA_NEW, !- <none>
   "
   
@@ -666,7 +663,7 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
     SET OA_NEW = @Min MDOT_OA_MAX OA_NEW, !- <none>
     SET FinalFlow = OA_NEW, !- <none>
     ENDIF, !- <none>
-    SET "+name_cut(econ_choice)+"MDOT_OA#{bias_sensor}_T = FinalFlow; !- <none>
+    SET "+name_cut(econ_choice)+"MDOT_OA#{bias_sensor}_#{$faulttype} = FinalFlow; !- <none>
   "
   
   return main_body
@@ -787,17 +784,17 @@ def econ_t_sensor_bias_ems_other(string_objects, workspace, bias_sensor, control
   
   string_objects << "
     EnergyManagementSystem:Subroutine,
-      RES_OA_SIGN#{econ_short_name}#{bias_sensor}_T, !- Name
-      SET TEMP_OA_SIGN = OA_SIGN_GB#{econ_short_name}#{bias_sensor}_T, !- <none>
-      SET TEMP_MIX_FLOW = MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_T, !- <none>
+      RES_OA_SIGN#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- Name
+      SET TEMP_OA_SIGN = OA_SIGN_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      SET TEMP_MIX_FLOW = MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
       SET TEMP_OA_FLOW = TEMP_OA_SIGN*TEMP_MIX_FLOW, !- <none>
       SET RECFLOW1 = 0, !- <none>
       SET RECFLOW2 = TEMP_MIX_FLOW-TEMP_OA_FLOW, !- <none>
       SET RECIR_FLOW = @MAX RECFLOW1 RECFLOW2, !- <none>
-      SET TEMP_RETENTH = RETENTH_GB#{econ_short_name}#{bias_sensor}_T, !- <none>
-      SET TEMP_RETHUMRAT = RETHUMRAT_GB#{econ_short_name}#{bias_sensor}_T, !- <none>
-      SET TEMP_OAENTH = OAENTH_GB#{econ_short_name}#{bias_sensor}_T, !- <none>
-      SET TEMP_OAHUMRAT = OAHUMRAT_GB#{econ_short_name}#{bias_sensor}_T, !- <none>
+      SET TEMP_RETENTH = RETENTH_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      SET TEMP_RETHUMRAT = RETHUMRAT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      SET TEMP_OAENTH = OAENTH_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      SET TEMP_OAHUMRAT = OAHUMRAT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
       SET TEMP_MIXENTH = RECIR_FLOW*TEMP_RETENTH, !- <none>
       SET TEMP_MIXENTH = TEMP_MIXENTH+TEMP_OA_FLOW*TEMP_OAENTH, !- <none>
       SET TEMP_MIXENTH = TEMP_MIXENTH/TEMP_MIX_FLOW, !- <none>
@@ -805,23 +802,23 @@ def econ_t_sensor_bias_ems_other(string_objects, workspace, bias_sensor, control
       SET TEMP_MIXHUMRAT = TEMP_MIXHUMRAT+TEMP_OA_FLOW*TEMP_OAHUMRAT, !- <none>
       SET TEMP_MIXHUMRAT = TEMP_MIXHUMRAT/TEMP_MIX_FLOW, !- <none>
       SET TEMP_MIXTEMP = @TdbFnHW TEMP_MIXENTH TEMP_MIXHUMRAT, !- <none>
-      SET TEMP_AA = MIXTEMPSET_GB#{econ_short_name}#{bias_sensor}_T-TEMP_MIXTEMP, !- <none>
-      SET RESIDUAL_GB#{econ_short_name}#{bias_sensor}_T = TEMP_AA; !- <none>
+      SET TEMP_AA = MIXTEMPSET_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}-TEMP_MIXTEMP, !- <none>
+      SET RESIDUAL_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = TEMP_AA; !- <none>
   "
   
   string_objects << "
     EnergyManagementSystem:Subroutine,
-      EMSSolveRegulaFalsi_OA_SIGN#{econ_short_name}#{bias_sensor}_T, !- Name
-      SET OA_SIGN_GB#{econ_short_name}#{bias_sensor}_T = LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_T, !- <none>
-      RUN RES_OA_SIGN#{econ_short_name}#{bias_sensor}_T, !- <none>
-      SET Y0 = RESIDUAL_GB#{econ_short_name}#{bias_sensor}_T, !- <none>
-      SET OA_SIGN_GB#{econ_short_name}#{bias_sensor}_T = UPLIMIT_GB#{econ_short_name}#{bias_sensor}_T, !- <none>
-      RUN RES_OA_SIGN#{econ_short_name}#{bias_sensor}_T, !- <none>
-      SET Y1 = RESIDUAL_GB#{econ_short_name}#{bias_sensor}_T, !- <none>
+      EMSSolveRegulaFalsi_OA_SIGN#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- Name
+      SET OA_SIGN_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      RUN RES_OA_SIGN#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      SET Y0 = RESIDUAL_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      SET OA_SIGN_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = UPLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      RUN RES_OA_SIGN#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      SET Y1 = RESIDUAL_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
       SET PROD = Y0*Y1, !- <none>
       IF Y0*Y1 > 0, !- <none>
-      SET FLAG_GB#{econ_short_name}#{bias_sensor}_T = -2, !- <none>
-      SET SOLN_GB#{econ_short_name}#{bias_sensor}_T = LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_T, !- <none>
+      SET FLAG_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = -2, !- <none>
+      SET SOLN_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
       RETURN, ! Error for solution
       ENDIF, !- <none>
       SET CONT = 1, !- <none>
@@ -835,11 +832,11 @@ def econ_t_sensor_bias_ems_other(string_objects, workspace, bias_sensor, control
       SET DY = 1.d-10, !- <none>
       ENDIF, !- <none>
       ENDIF, !- <none>
-      SET XTemp = Y0*UPLIMIT_GB#{econ_short_name}#{bias_sensor}_T, !- <none>
-      SET XTemp = (XTemp-Y1*LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_T)/DY, !- <none>
-      SET OA_SIGN_GB#{econ_short_name}#{bias_sensor}_T = XTemp, !- <none>
-      RUN RES_OA_SIGN#{econ_short_name}#{bias_sensor}_T, !- <none>
-      SET YTemp = RESIDUAL_GB#{econ_short_name}#{bias_sensor}_T, !- <none>
+      SET XTemp = Y0*UPLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      SET XTemp = (XTemp-Y1*LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype})/DY, !- <none>
+      SET OA_SIGN_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = XTemp, !- <none>
+      RUN RES_OA_SIGN#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
+      SET YTemp = RESIDUAL_GB#{econ_short_name}#{bias_sensor}_#{$faulttype}, !- <none>
       SET NITE = NITE+1, !- <none>
       IF YTemp < 0.0001 && YTemp+0.0001 > 0, !- <none>
       SET CONT = 0, !- <none>
@@ -850,101 +847,101 @@ def econ_t_sensor_bias_ems_other(string_objects, workspace, bias_sensor, control
       IF CONT > 0.0d0, !- <none>
       IF Y0 < 0.0d0, !- <none>
       IF YTemp < 0.0d0, !- <none>
-      SET LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_T = XTemp, !- <none>
+      SET LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = XTemp, !- <none>
       SET Y0 = YTemp, !- <none>
       ELSE, !- <none>
-      SET UPLIMIT_GB#{econ_short_name}#{bias_sensor}_T = XTemp, !- <none>
+      SET UPLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = XTemp, !- <none>
       SET Y1 = YTemp, !- <none>
       ENDIF, !- <none>
       ELSE, !- <none>
       IF YTemp < 0.0d0, !- <none>
-      SET UPLIMIT_GB#{econ_short_name}#{bias_sensor}_T = XTemp, !- <none>
+      SET UPLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = XTemp, !- <none>
       SET Y1 = YTemp, !- <none>
       ELSE, !- <none>
-      SET LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_T = XTemp, !- <none>
+      SET LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = XTemp, !- <none>
       SET Y0 = YTemp, !- <none>
       ENDIF, !- <none>
       ENDIF, !- <none>
       ENDIF, !- <none>
       ENDWHILE, !- <none>
       IF CONV == 1, !- <none>
-      SET FLAG_GB#{econ_short_name}#{bias_sensor}_T = NITE, !- <none>
+      SET FLAG_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = NITE, !- <none>
       ELSE,
-      SET FLAG_GB#{econ_short_name}#{bias_sensor}_T = -1, !- <none>
+      SET FLAG_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = -1, !- <none>
       ENDIF, !- <none>
-      SET SOLN_GB#{econ_short_name}#{bias_sensor}_T = XTemp; !- <none>
+      SET SOLN_GB#{econ_short_name}#{bias_sensor}_#{$faulttype} = XTemp; !- <none>
   "
   
   string_objects << "
     EnergyManagementSystem:ProgramCallingManager,
-      EMSCallt_bias"+name_cut(econ_choice)+"#{bias_sensor}_T, !- Name
+      EMSCallt_bias"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype}, !- Name
       InsideHVACSystemIterationLoop,       !- EnergyPlus Model Calling Point
-      t_bias"+name_cut(econ_choice)+"#{bias_sensor}_T, !- Name
+      t_bias"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype}, !- Name
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      RESIDUAL_GB#{econ_short_name}#{bias_sensor}_T;
+      RESIDUAL_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_T;
+      LOWLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      UPLIMIT_GB#{econ_short_name}#{bias_sensor}_T;
+      UPLIMIT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      FLAG_GB#{econ_short_name}#{bias_sensor}_T;
+      FLAG_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      SOLN_GB#{econ_short_name}#{bias_sensor}_T;
+      SOLN_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      OA_SIGN_GB#{econ_short_name}#{bias_sensor}_T;
+      OA_SIGN_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_T;
+      MIX_FLOW_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      RETENTH_GB#{econ_short_name}#{bias_sensor}_T;
+      RETENTH_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      RETHUMRAT_GB#{econ_short_name}#{bias_sensor}_T;
+      RETHUMRAT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      OAENTH_GB#{econ_short_name}#{bias_sensor}_T;
+      OAENTH_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      OAHUMRAT_GB#{econ_short_name}#{bias_sensor}_T;
+      OAHUMRAT_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      MIXTEMPSET_GB#{econ_short_name}#{bias_sensor}_T;
+      MIXTEMPSET_GB#{econ_short_name}#{bias_sensor}_#{$faulttype};
   "
   
   string_objects << "   
     EnergyManagementSystem:Actuator,
-      "+name_cut(econ_choice)+"MDOT_OA#{bias_sensor}_T,        !- Name
+      "+name_cut(econ_choice)+"MDOT_OA#{bias_sensor}_#{$faulttype},        !- Name
       "+econ_choice+", !- Actuated Component Unique Name
       Outdoor Air Controller,                                  !- Actuated Component Type
       Air Mass Flow Rate;                           !- Actuated Component Control Type
@@ -981,35 +978,35 @@ def econ_t_sensor_bias_ems_other(string_objects, workspace, bias_sensor, control
   
   string_objects << "
     EnergyManagementSystem:InternalVariable,
-      DesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_T,
+      DesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype},
       "+airsystem_name+",
       Intermediate Air System Main Supply Volume Flow Rate;
   "
   
   string_objects << "
     EnergyManagementSystem:InternalVariable,
-      CMDesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_T,
+      CMDesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype},
       "+airsystem_name+",
       Intermediate Air System "+sizing_option+" Peak Cooling Mass Flow Rate;
   "
   
   string_objects << "
     EnergyManagementSystem:InternalVariable,
-      HMDesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_T,
+      HMDesAirflow"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype},
       "+airsystem_name+",
       Intermediate Air System "+sizing_option+" Peak Heating Mass Flow Rate;
   "
   
   string_objects << "
     EnergyManagementSystem:InternalVariable,
-      MinOAMdot"+name_cut(econ_choice)+"#{bias_sensor}_T,
+      MinOAMdot"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype},
       "+econ_choice+",
       Outdoor Air Controller Minimum Mass Flow Rate;
   "
   
   string_objects << "
     EnergyManagementSystem:InternalVariable,
-      MaxOAMdot"+name_cut(econ_choice)+"#{bias_sensor}_T,
+      MaxOAMdot"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype},
       "+econ_choice+",
       Outdoor Air Controller Maximum Mass Flow Rate;
   "
@@ -1027,9 +1024,7 @@ def econ_t_sensor_bias_ems_other(string_objects, workspace, bias_sensor, control
         for i in 0..vent_num_zone-1  #for each zone
           outdoorairspecs.each do |outdoorairspec|
             
-          #####################################################
 	      oaschedule_name = outdoorairspec.getString(6).to_s
-	      #####################################################
             
             if controllermechventilation.getString(4+3*i+2).to_s.eql?(outdoorairspec.getString(0).to_s)
               zone_name = controllermechventilation.getString(4+3*i+1).to_s
@@ -1037,25 +1032,25 @@ def econ_t_sensor_bias_ems_other(string_objects, workspace, bias_sensor, control
               zone_name_tag = name_cut(zone_name)
               string_objects << "
                 EnergyManagementSystem:InternalVariable,
-                  "+zone_name_tag+"_VOL#{bias_sensor}_T,
+                  "+zone_name_tag+"_VOL#{bias_sensor}_#{$faulttype},
                   "+zone_name+",
                   Zone Air Volume;
               "
               string_objects << "
                 EnergyManagementSystem:InternalVariable,
-                  "+zone_name_tag+"_MUL#{bias_sensor}_T,
+                  "+zone_name_tag+"_MUL#{bias_sensor}_#{$faulttype},
                   "+zone_name+",
                   Zone Multiplier;
               "
               string_objects << "
                 EnergyManagementSystem:InternalVariable,
-                  "+zone_name_tag+"_LIST_MUL#{bias_sensor}_T,
+                  "+zone_name_tag+"_LIST_MUL#{bias_sensor}_#{$faulttype},
                   "+zone_name+",
                   Zone List Multiplier;
               "
               string_objects << "
                 EnergyManagementSystem:InternalVariable,
-                  "+zone_name_tag+"_AREA#{bias_sensor}_T,
+                  "+zone_name_tag+"_AREA#{bias_sensor}_#{$faulttype},
                   "+zone_name+",
                   Zone Floor Area;
               "
@@ -1065,7 +1060,7 @@ def econ_t_sensor_bias_ems_other(string_objects, workspace, bias_sensor, control
 				  people_name = people.getString(0).to_s
 				  string_objects << "
                     EnergyManagementSystem:Sensor,
-                    "+zone_name_tag+"_PEOPLE#{bias_sensor}_T, !- Name
+                    "+zone_name_tag+"_PEOPLE#{bias_sensor}_#{$faulttype}, !- Name
                     "+people_name+",                        !- Output:Variable or Output:Meter Index Key Name
                     Zone People Occupant Count;                !- Output:Variable or Output:Meter Name
                   "
@@ -1074,7 +1069,7 @@ def econ_t_sensor_bias_ems_other(string_objects, workspace, bias_sensor, control
 			  #####################################################
               string_objects << "
                 EnergyManagementSystem:Sensor,
-                  "+zone_name_tag+"_OA_SCH#{bias_sensor}_T, !- Name
+                  "+zone_name_tag+"_OA_SCH#{bias_sensor}_#{$faulttype}, !- Name
                   "+oaschedule_name+",                        !- Output:Variable or Output:Meter Index Key Name
                   Schedule Value;                !- Output:Variable or Output:Meter Name
               "
@@ -1087,14 +1082,14 @@ def econ_t_sensor_bias_ems_other(string_objects, workspace, bias_sensor, control
   
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(airsystem_name)+"_Htg#{bias_sensor}_T,
+      "+name_cut(airsystem_name)+"_Htg#{bias_sensor}_#{$faulttype},
       "+airsystem_name+",
       Air System Heating Coil Total Heating Energy;
   "
   
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(airsystem_name)+"_Ctg#{bias_sensor}_T,
+      "+name_cut(airsystem_name)+"_Ctg#{bias_sensor}_#{$faulttype},
       "+airsystem_name+",
       Air System Cooling Coil Total Cooling Energy;
   "
@@ -1102,21 +1097,21 @@ def econ_t_sensor_bias_ems_other(string_objects, workspace, bias_sensor, control
   ret_node_name = controlleroutdoorair.getString(2).to_s
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(econ_choice)+"RETTemp1#{bias_sensor}_T,  !- Name
+      "+name_cut(econ_choice)+"RETTemp1#{bias_sensor}_#{$faulttype},  !- Name
       "+ret_node_name+",                        !- Output:Variable or Output:Meter Index Key Name
       System Node Temperature;                !- Output:Variable or Output:Meter Name
   "
   
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(econ_choice)+"RETOmega1#{bias_sensor}_T,  !- Name
+      "+name_cut(econ_choice)+"RETOmega1#{bias_sensor}_#{$faulttype},  !- Name
       "+ret_node_name+",                        !- Output:Variable or Output:Meter Index Key Name
       System Node Humidity Ratio;                !- Output:Variable or Output:Meter Name
   "
   
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(econ_choice)+"RETPressure1#{bias_sensor}_T,  !- Name
+      "+name_cut(econ_choice)+"RETPressure1#{bias_sensor}_#{$faulttype},  !- Name
       "+ret_node_name+",                        !- Output:Variable or Output:Meter Index Key Name
       System Node Pressure;                !- Output:Variable or Output:Meter Name
   "
@@ -1124,7 +1119,7 @@ def econ_t_sensor_bias_ems_other(string_objects, workspace, bias_sensor, control
   mx_node_name = controlleroutdoorair.getString(3).to_s
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_T,  !- Name
+      "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype},  !- Name
       "+mx_node_name+",                        !- Output:Variable or Output:Meter Index Key Name
       System Node Setpoint Temperature;                !- Output:Variable or Output:Meter Name
   "
@@ -1132,21 +1127,21 @@ def econ_t_sensor_bias_ems_other(string_objects, workspace, bias_sensor, control
   oa_node_name = controlleroutdoorair.getString(4).to_s
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(econ_choice)+"OATTemp1#{bias_sensor}_T,  !- Name
+      "+name_cut(econ_choice)+"OATTemp1#{bias_sensor}_#{$faulttype},  !- Name
       "+oa_node_name+",                        !- Output:Variable or Output:Meter Index Key Name
       System Node Temperature;                !- Output:Variable or Output:Meter Name
   "
   
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(econ_choice)+"OATOmega1#{bias_sensor}_T,  !- Name
+      "+name_cut(econ_choice)+"OATOmega1#{bias_sensor}_#{$faulttype},  !- Name
       "+oa_node_name+",                        !- Output:Variable or Output:Meter Index Key Name
       System Node Humidity Ratio;                !- Output:Variable or Output:Meter Name
   "
   
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(econ_choice)+"MixAirFlow_CTRL#{bias_sensor}_T,  !- Name
+      "+name_cut(econ_choice)+"MixAirFlow_CTRL#{bias_sensor}_#{$faulttype},  !- Name
       "+airsystem_name+",                        !- Output:Variable or Output:Meter Index Key Name
       Air System Mixed Air Mass Flow Rate;                !- Output:Variable or Output:Meter Name
   "
@@ -1157,7 +1152,7 @@ def econ_t_sensor_bias_ems_other(string_objects, workspace, bias_sensor, control
     # check high humidity control before adding
     string_objects << "
       EnergyManagementSystem:Sensor,
-        ZoneHumid"+name_cut(econ_choice)+"#{bias_sensor}_T,  !- Name
+        ZoneHumid"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype},  !- Name
         "+humidistat_zone+",                        !- Output:Variable or Output:Meter Index Key Name
         Zone Air Humidity Ratio;                !- Output:Variable or Output:Meter Name
     "
@@ -1165,7 +1160,7 @@ def econ_t_sensor_bias_ems_other(string_objects, workspace, bias_sensor, control
     # check high humidity control before adding
     string_objects << "
       EnergyManagementSystem:Sensor,
-        ZoneHumidLOAD"+name_cut(econ_choice)+"#{bias_sensor}_T,  !- Name
+        ZoneHumidLOAD"+name_cut(econ_choice)+"#{bias_sensor}_#{$faulttype},  !- Name
         "+humidistat_zone+",                        !- Output:Variable or Output:Meter Index Key Name
         Zone Predicted Moisture Load to Humidifying Setpoint Moisture Transfer Rate;                !- Output:Variable or Output:Meter Name
     "
@@ -1175,7 +1170,7 @@ def econ_t_sensor_bias_ems_other(string_objects, workspace, bias_sensor, control
   if not controlleroutdoorair.getString(20).to_s.eql?("")
     string_objects << "
       EnergyManagementSystem:Sensor,
-        ECONCTRL"+name_cut(econ_choice)+"_SCH#{bias_sensor}_T, !- Name
+        ECONCTRL"+name_cut(econ_choice)+"_SCH#{bias_sensor}_#{$faulttype}, !- Name
         "+controlleroutdoorair.getString(20).to_s+", !- Schedule Name
         Schedule Value; !- Output:Variable
     "
@@ -1185,7 +1180,7 @@ def econ_t_sensor_bias_ems_other(string_objects, workspace, bias_sensor, control
   if false
     string_objects << "
       EnergyManagementSystem:Sensor,
-        NIGHTVENT_SCH#{bias_sensor}_T, !- Name
+        NIGHTVENT_SCH#{bias_sensor}_#{$faulttype}, !- Name
         [Schedule name from Ruby], !- Schedule Name
         Schedule Value; !- Output:Variable
     "
@@ -1195,7 +1190,7 @@ def econ_t_sensor_bias_ems_other(string_objects, workspace, bias_sensor, control
   if not controlleroutdoorair.getString(18).to_s.eql?("")
     string_objects << "
       EnergyManagementSystem:Sensor,
-        "+name_cut(econ_choice)+"_MAX_FRAC_SCH#{bias_sensor}_T, !- Name
+        "+name_cut(econ_choice)+"_MAX_FRAC_SCH#{bias_sensor}_#{$faulttype}, !- Name
         "+controlleroutdoorair.getString(18).to_s+", !- Schedule Name
         Schedule Value; !- Output:Variable
     "
@@ -1205,7 +1200,7 @@ def econ_t_sensor_bias_ems_other(string_objects, workspace, bias_sensor, control
   if not controlleroutdoorair.getString(16).to_s.eql?("")
     string_objects << "
       EnergyManagementSystem:Sensor,
-        "+name_cut(econ_choice)+"_MIN_SCH#{bias_sensor}_T, !- Name
+        "+name_cut(econ_choice)+"_MIN_SCH#{bias_sensor}_#{$faulttype}, !- Name
         "+controlleroutdoorair.getString(16).to_s+", !- Schedule Name
         Schedule Value; !- Output:Variable
     "
@@ -1215,7 +1210,7 @@ def econ_t_sensor_bias_ems_other(string_objects, workspace, bias_sensor, control
   if not controlleroutdoorair.getString(17).to_s.eql?("")
     string_objects << "
       EnergyManagementSystem:Sensor,
-        "+name_cut(econ_choice)+"_MIN_FRAC_SCH#{bias_sensor}_T, !- Name
+        "+name_cut(econ_choice)+"_MIN_FRAC_SCH#{bias_sensor}_#{$faulttype}, !- Name
         "+controlleroutdoorair.getString(17).to_s+", !- Schedule Name
         Schedule Value; !- Output:Variable
     "

--- a/fault_measures_2017/DuctFouling/measure.xml
+++ b/fault_measures_2017/DuctFouling/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>duct_fouling</name>
   <uid>20a9d083-d915-4653-8893-d94a6dbc72d8</uid>
-  <version_id>fa25c95f-1ba9-41a5-9304-794dd395f455</version_id>
-  <version_modified>20190411T174343Z</version_modified>
+  <version_id>00df8d90-ddd4-498c-833a-91a07210450f</version_id>
+  <version_modified>20190411T181025Z</version_modified>
   <xml_checksum>266557E5</xml_checksum>
   <class_name>DuctFouling</class_name>
   <display_name>Duct Fouling</display_name>

--- a/fault_measures_2017/DuctFouling/measure.xml
+++ b/fault_measures_2017/DuctFouling/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>duct_fouling</name>
   <uid>20a9d083-d915-4653-8893-d94a6dbc72d8</uid>
-  <version_id>34893d7a-210d-46ec-9425-6514a73cdb14</version_id>
-  <version_modified>20190409T221839Z</version_modified>
+  <version_id>fa25c95f-1ba9-41a5-9304-794dd395f455</version_id>
+  <version_modified>20190411T174343Z</version_modified>
   <xml_checksum>266557E5</xml_checksum>
   <class_name>DuctFouling</class_name>
   <display_name>Duct Fouling</display_name>
@@ -25,7 +25,7 @@
       </choices>
     </argument>
     <argument>
-      <name>evap_flow_reduction</name>
+      <name>flow_decrease_ratio</name>
       <display_name>Decrease of air mass flow rate ratio when the fans are running at their maximum speed (0-1). (-)</display_name>
       <type>Double</type>
       <required>true</required>
@@ -90,7 +90,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>A85263CB</checksum>
+      <checksum>58542651</checksum>
     </file>
   </files>
 </measure>

--- a/fault_measures_2017/LightingSetbackErrorEarlyTermination/measure.xml
+++ b/fault_measures_2017/LightingSetbackErrorEarlyTermination/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>lighting_setback_error_early_termination</name>
   <uid>4068e01b-f572-4805-9d49-a5067c5246ff</uid>
-  <version_id>d2bf6d37-5cb6-4303-8802-5d1d717df5b4</version_id>
-  <version_modified>20190306T230535Z</version_modified>
+  <version_id>3ed7f712-1ea7-466c-910a-3e9be79a9583</version_id>
+  <version_modified>20190415T171026Z</version_modified>
   <xml_checksum>9B7BB4D8</xml_checksum>
   <class_name>LightingSetbackErrorEarlyTermination</class_name>
   <display_name>Lighting Setback Error: Early Termination</display_name>
@@ -248,12 +248,6 @@
       <checksum>652BFEE8</checksum>
     </file>
     <file>
-      <filename>fdd_thermostat_light.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>E4CBEA96</checksum>
-    </file>
-    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>1.4.0</identifier>
@@ -263,6 +257,12 @@
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
       <checksum>168C6198</checksum>
+    </file>
+    <file>
+      <filename>fdd_thermostat_light.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>9E4D416E</checksum>
     </file>
   </files>
 </measure>

--- a/fault_measures_2017/LightingSetbackErrorEarlyTermination/resources/fdd_thermostat_light.rb
+++ b/fault_measures_2017/LightingSetbackErrorEarlyTermination/resources/fdd_thermostat_light.rb
@@ -656,10 +656,8 @@ module OsLib_FDD_light
     changetime = times[0]
     i = 0
 	
-    p_tol_min = 30 # percentage
     p_tol_max = 30 # percentage
 	
-    tol_min = values.min.abs*p_tol_min/100
     tol_max = values.max.abs*p_tol_max/100
 		
     # any lighting fraction change after 3am should be a result of building opening

--- a/fault_measures_2017/ReturnAirDuctLeakages/measure.rb
+++ b/fault_measures_2017/ReturnAirDuctLeakages/measure.rb
@@ -10,7 +10,7 @@
 require "#{File.dirname(__FILE__)}/resources/ControllerOutdoorAirFlow_DuctLeakage"
 
 $allchoices = '* ALL Controller:OutdoorAir *'
-$faulttype = 'DL'
+$faulttype = 'RDL'
 
 # start the measure
 class ReturnAirDuctLeakages < OpenStudio::Ruleset::WorkspaceUserScript
@@ -120,7 +120,6 @@ class ReturnAirDuctLeakages < OpenStudio::Ruleset::WorkspaceUserScript
 	time_step = OpenStudio::Ruleset::OSArgument::makeDoubleArgument('time_step', false)
 	dts = workspace.getObjectsByType('Timestep'.to_IddObjectType)
 	dts.each do |dt|
-	 runner.registerInfo("Simulation Timestep = #{1./dt.getString(0).get.clone.to_f}")
 	 time_step = (1./dt.getString(0).get.clone.to_f).to_s
 	end
     if leak_ratio == 0

--- a/fault_measures_2017/ReturnAirDuctLeakages/measure.xml
+++ b/fault_measures_2017/ReturnAirDuctLeakages/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>return_air_duct_leakages</name>
   <uid>e28746df-aa8c-4f6e-a2be-6e2ff3c5e7dd</uid>
-  <version_id>50af0877-f46c-43d5-8253-99a2dc9198aa</version_id>
-  <version_modified>20190411T023337Z</version_modified>
+  <version_id>3c17eb48-998a-4481-970a-3b79ce292f8c</version_id>
+  <version_modified>20190411T171838Z</version_modified>
   <xml_checksum>FAAEB4D1</xml_checksum>
   <class_name>ReturnAirDuctLeakages</class_name>
   <display_name>Return Air Duct Leakages</display_name>
@@ -120,7 +120,7 @@
       <filename>ControllerOutdoorAirFlow_DuctLeakage.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>0984077D</checksum>
+      <checksum>540D615D</checksum>
     </file>
     <file>
       <version>
@@ -131,7 +131,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>FF192B87</checksum>
+      <checksum>C26FB0BF</checksum>
     </file>
   </files>
 </measure>

--- a/fault_measures_2017/ReturnAirDuctLeakages/measure.xml
+++ b/fault_measures_2017/ReturnAirDuctLeakages/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>return_air_duct_leakages</name>
   <uid>e28746df-aa8c-4f6e-a2be-6e2ff3c5e7dd</uid>
-  <version_id>3c17eb48-998a-4481-970a-3b79ce292f8c</version_id>
-  <version_modified>20190411T171838Z</version_modified>
+  <version_id>75af0fbf-1800-4bc0-bca0-b2761b055bb6</version_id>
+  <version_modified>20190411T174344Z</version_modified>
   <xml_checksum>FAAEB4D1</xml_checksum>
   <class_name>ReturnAirDuctLeakages</class_name>
   <display_name>Return Air Duct Leakages</display_name>

--- a/fault_measures_2017/ReturnAirDuctLeakages/resources/ControllerOutdoorAirFlow_DuctLeakage.rb
+++ b/fault_measures_2017/ReturnAirDuctLeakages/resources/ControllerOutdoorAirFlow_DuctLeakage.rb
@@ -129,26 +129,26 @@ def econ_ductleakage_ems_main_body(workspace, controlleroutdoorair, leak_ratio, 
   end
   main_body = "
     EnergyManagementSystem:Program,
-      t_bias"+name_cut(econ_choice)+"_DL, !- Name
+      t_bias"+name_cut(econ_choice)+"_#{$faulttype}, !- Name
       SET DELTASMALL = 0.00001, !- Program Line 1
       SET SMALLMASSFLOW = 0.001, !- Program Line 2
       SET SMALLVOLFLOW = 0.001, !- Program Line 3
       SET HIGHHUMCTRL = False, !- <none>
       SET NIGHTVENT = False, !- <none>
       SET ECON_OP = True, !- <none>
-      SET MIX_FLOW_GB#{econ_short_name}_DL = "+name_cut(econ_choice)+"MixAirFlow_CTRL_DL, !- <none>
-      IF MIX_FLOW_GB#{econ_short_name}_DL < SMALLMASSFLOW, !- Check if the duct has airflow
+      SET MIX_FLOW_GB#{econ_short_name}_#{$faulttype} = "+name_cut(econ_choice)+"MixAirFlow_CTRL_#{$faulttype}, !- <none>
+      IF MIX_FLOW_GB#{econ_short_name}_#{$faulttype} < SMALLMASSFLOW, !- Check if the duct has airflow
       SET FinalFlow = 0.00, !- <none>
       RETURN, !- <none>
       ENDIF, !- <none>
   "
 
   main_body = main_body+"
-    SET RETTmp = "+name_cut(econ_choice)+"RETTemp1_DL, !- <none>
-    SET RETHumRat = "+name_cut(econ_choice)+"RETOmega1_DL, !- <none>
-    SET OATmp = "+name_cut(econ_choice)+"OATTemp1_DL, !- <none>
-    SET OAHumRat = "+name_cut(econ_choice)+"OATOmega1_DL, !- <none>
-    SET PTmp = "+name_cut(econ_choice)+"RETPressure1_DL, !- <none>
+    SET RETTmp = "+name_cut(econ_choice)+"RETTemp1_#{$faulttype}, !- <none>
+    SET RETHumRat = "+name_cut(econ_choice)+"RETOmega1_#{$faulttype}, !- <none>
+    SET OATmp = "+name_cut(econ_choice)+"OATTemp1_#{$faulttype}, !- <none>
+    SET OAHumRat = "+name_cut(econ_choice)+"OATOmega1_#{$faulttype}, !- <none>
+    SET PTmp = "+name_cut(econ_choice)+"RETPressure1_#{$faulttype}, !- <none>
     IF PTmp < DELTASMALL, !- <none>
     SET PTmp = 101325.0, !- Zero pressure during warmup may crash the code
     ENDIF, !- <none>
@@ -166,12 +166,12 @@ def econ_ductleakage_ems_main_body(workspace, controlleroutdoorair, leak_ratio, 
   "
 	
   main_body = main_body+"
-      SET VDOT_DES = DesAirflow"+name_cut(econ_choice)+"_DL, !- <none>
-      SET CMDOT_D = CMDesAirflow"+name_cut(econ_choice)+"_DL, !- <none>
-      SET HMDOT_D = HMDesAirflow"+name_cut(econ_choice)+"_DL, !- <none>
+      SET VDOT_DES = DesAirflow"+name_cut(econ_choice)+"_#{$faulttype}, !- <none>
+      SET CMDOT_D = CMDesAirflow"+name_cut(econ_choice)+"_#{$faulttype}, !- <none>
+      SET HMDOT_D = HMDesAirflow"+name_cut(econ_choice)+"_#{$faulttype}, !- <none>
       SET MDOT_DES = @Max CMDOT_D HMDOT_D, !- <none>
-      SET MDOT_OA_MIN = MinOAMdot"+name_cut(econ_choice)+"_DL, !- <none>
-      SET MDOT_OA_MAX = MaxOAMdot"+name_cut(econ_choice)+"_DL, !- <none>
+      SET MDOT_OA_MIN = MinOAMdot"+name_cut(econ_choice)+"_#{$faulttype}, !- <none>
+      SET MDOT_OA_MAX = MaxOAMdot"+name_cut(econ_choice)+"_#{$faulttype}, !- <none>
       IF VDOT_DES > SMALLVOLFLOW, !- <none>
       SET MIN_FRAC = MDOT_OA_MIN/MDOT_DES, !- no if statement for airloop existence because the code won't work without an airloop
       SET MIN_FLOW = MDOT_OA_MIN, !- <none>
@@ -183,7 +183,7 @@ def econ_ductleakage_ems_main_body(workspace, controlleroutdoorair, leak_ratio, 
   
   if not controlleroutdoorair.getString(16).to_s.eql?("")  #Minimum Outdoor Air Schedule Name
     main_body = main_body+"
-      SET MIN_SCH_VALUE = "+name_cut(econ_choice)+"_MIN_SCH_DL, !- <none>
+      SET MIN_SCH_VALUE = "+name_cut(econ_choice)+"_MIN_SCH_#{$faulttype}, !- <none>
       SET MIN_SCH_VALUE = @MAX MIN_SCH_VALUE 0.00, !- <none>
       SET MIN_SCH_VALUE = @MIN MIN_SCH_VALUE 1.00, !- <none>
       SET MIN_FRAC = MIN_SCH_VALUE*MIN_FRAC, !- <none>
@@ -214,7 +214,7 @@ def econ_ductleakage_ems_main_body(workspace, controlleroutdoorair, leak_ratio, 
               zone_name = name_cut(controllermechventilation.getString(4+3*i+1).to_s)
               if outdoorairspec.numFields == 7  #multiply the number with a schedule
                 main_body = main_body+"
-                  SET MECH_SCH = "+zone_name+"_OA_SCH_DL, !- NEED A SENSOR FOR THE SCHEDULE
+                  SET MECH_SCH = "+zone_name+"_OA_SCH_#{$faulttype}, !- NEED A SENSOR FOR THE SCHEDULE
                 "
               else
                 main_body = main_body+"
@@ -223,9 +223,9 @@ def econ_ductleakage_ems_main_body(workspace, controlleroutdoorair, leak_ratio, 
               end
               if outdoorairspec.getString(1).to_s.eql?("Sum") #add code for summation
                 main_body = main_body+"
-                  SET ZONE_VOL = "+zone_name+"_VOL_DL, !- NEED INTERNAL VARIABLE FOR ZONE VOLUME
-                  SET ZONE_MUL = "+zone_name+"_MUL_DL, !- NEED INTERNAL VARIABLE FOR ZONE MULTIPLIER
-                  SET ZONE_LIST_MUL = "+zone_name+"_LIST_MUL_DL, !- NEED INTERNAL VARIABLE FOR ZONE LIST MULTIPLIER
+                  SET ZONE_VOL = "+zone_name+"_VOL_#{$faulttype}, !- NEED INTERNAL VARIABLE FOR ZONE VOLUME
+                  SET ZONE_MUL = "+zone_name+"_MUL_#{$faulttype}, !- NEED INTERNAL VARIABLE FOR ZONE MULTIPLIER
+                  SET ZONE_LIST_MUL = "+zone_name+"_LIST_MUL_#{$faulttype}, !- NEED INTERNAL VARIABLE FOR ZONE LIST MULTIPLIER
                 "
 				#####################################################
 				if peoples.empty?
@@ -236,7 +236,7 @@ def econ_ductleakage_ems_main_body(workspace, controlleroutdoorair, leak_ratio, 
 				  peoples.each do |people|
 			        if people.getString(1).to_s.eql?(controllermechventilation.getString(4+3*i+1).to_s)
 				      main_body = main_body+"
-                        SET ZONE_PPL = "+zone_name+"_PEOPLE#{bias_sensor}_T, !- NEED SENSOR FOR ZONE People Occupant Count
+                        SET ZONE_PPL = "+zone_name+"_PEOPLE#{bias_sensor}_T_#{$faulttype}, !- NEED SENSOR FOR ZONE People Occupant Count
 				      "
 				    else
 				      main_body = main_body+"
@@ -250,7 +250,7 @@ def econ_ductleakage_ems_main_body(workspace, controlleroutdoorair, leak_ratio, 
                   SET IND_OA = #{outdoorairspec.getString(2).to_s}, !- Zone occupant flow rate
                   SET IND_OA = IND_OA*ZONE_MUL*ZONE_LIST_MUL*ZONE_PPL, !- <none>
                   SET OA_MECH = OA_MECH+IND_OA*MECH_SCH, !- <none>
-                  SET ZONE_AREA = "+zone_name+"_AREA_DL, !- NEED INTERNAL VARIABLE FOR ZONE FLOOR AREA
+                  SET ZONE_AREA = "+zone_name+"_AREA_#{$faulttype}, !- NEED INTERNAL VARIABLE FOR ZONE FLOOR AREA
                   SET IND_OA = "+outdoorairspec.getString(3).to_s+"*ZONE_AREA, !- Zone floor area flow rate
                   SET IND_OA = IND_OA*ZONE_MUL*ZONE_LIST_MUL, !- <none>
                   SET OA_MECH = OA_MECH+IND_OA*MECH_SCH, !- <none>
@@ -264,14 +264,14 @@ def econ_ductleakage_ems_main_body(workspace, controlleroutdoorair, leak_ratio, 
               else #add code for maximum
                 main_body = main_body+"
                   SET IND_OA_FIN = 0.0, !- For maximum calculation
-                  SET ZONE_VOL = "+zone_name+"_VOL_DL, !- NEED INTERNAL VARIABLE FOR ZONE VOLUME
-                  SET ZONE_MUL = "+zone_name+"_MUL_DL, !- NEED INTERNAL VARIABLE FOR ZONE MULTIPLIER
-                  SET ZONE_LIST_MUL = "+zone_name+"_LIST_MUL_DL, !- NEED INTERNAL VARIABLE FOR ZONE LIST MULTIPLIER
-                  SET ZONE_PPL = "+zone_name+"_PEOPLE_DL, !- NEED SENSOR FOR ZONE People Occupant Count
+                  SET ZONE_VOL = "+zone_name+"_VOL_#{$faulttype}, !- NEED INTERNAL VARIABLE FOR ZONE VOLUME
+                  SET ZONE_MUL = "+zone_name+"_MUL_#{$faulttype}, !- NEED INTERNAL VARIABLE FOR ZONE MULTIPLIER
+                  SET ZONE_LIST_MUL = "+zone_name+"_LIST_MUL_#{$faulttype}, !- NEED INTERNAL VARIABLE FOR ZONE LIST MULTIPLIER
+                  SET ZONE_PPL = "+zone_name+"_PEOPLE_#{$faulttype}, !- NEED SENSOR FOR ZONE People Occupant Count
                   SET IND_OA = #{outdoorairspec.getString(2).to_s}, !- Zone occupant flow rate
                   SET IND_OA = IND_OA*ZONE_MUL*ZONE_LIST_MUL*ZONE_PPL, !- <none>
                   SET IND_OA_FIN = @Max IND_OA_FIN IND_OA, !- <none>
-                  SET ZONE_AREA = "+zone_name+"_AREA_DL, !- NEED INTERNAL VARIABLE FOR ZONE FLOOR AREA
+                  SET ZONE_AREA = "+zone_name+"_AREA_#{$faulttype}, !- NEED INTERNAL VARIABLE FOR ZONE FLOOR AREA
                   SET IND_OA = "+outdoorairspec.getString(3).to_s+"*ZONE_AREA, !- Zone floor area flow rate
                   SET IND_OA = IND_OA*ZONE_MUL*ZONE_LIST_MUL, !- <none>
                   SET IND_OA_FIN = @Max IND_OA_FIN IND_OA, !- <none>
@@ -305,15 +305,15 @@ def econ_ductleakage_ems_main_body(workspace, controlleroutdoorair, leak_ratio, 
     SET TDiff = RETTmp-OATmp, !- <none>
     SET TDiff = @Abs TDiff, !- <none>
     IF TDiff > DELTASMALL, !- <none>
-    SET OA_SIGN = (RETTmp-"+name_cut(econ_choice)+"MASetPoint1_DL)/(RETTmp-OATmp), !- Initialize the signal
+    SET OA_SIGN = (RETTmp-"+name_cut(econ_choice)+"MASetPoint1_#{$faulttype})/(RETTmp-OATmp), !- Initialize the signal
     ELSE, !- <none>
-    IF RETTmp < "+name_cut(econ_choice)+"MASetPoint1_DL && RETTmp >= OATmp, !- <none>
+    IF RETTmp < "+name_cut(econ_choice)+"MASetPoint1_#{$faulttype} && RETTmp >= OATmp, !- <none>
     SET OA_SIGN = -1, !- <none>
-    ELSEIF RETTmp < "+name_cut(econ_choice)+"MASetPoint1_DL && RETTmp < OATmp, !- <none>
+    ELSEIF RETTmp < "+name_cut(econ_choice)+"MASetPoint1_#{$faulttype} && RETTmp < OATmp, !- <none>
     SET OA_SIGN = 1, !- <none>
-    ELSEIF RETTmp >= "+name_cut(econ_choice)+"MASetPoint1_DL && RETTmp >= OATmp,
+    ELSEIF RETTmp >= "+name_cut(econ_choice)+"MASetPoint1_#{$faulttype} && RETTmp >= OATmp,
     SET OA_SIGN = 1, !- <none>
-    ELSEIF RETTmp >= "+name_cut(econ_choice)+"MASetPoint1_DL && RETTmp < OATmp,
+    ELSEIF RETTmp >= "+name_cut(econ_choice)+"MASetPoint1_#{$faulttype} && RETTmp < OATmp,
     SET OA_SIGN = -1, !- <none>
     ENDIF, !- <none>
     ENDIF, !- <none>
@@ -388,7 +388,7 @@ def econ_ductleakage_ems_main_body(workspace, controlleroutdoorair, leak_ratio, 
       SET HIGHHUMCTRL = False, !- <none>
       ELSE, !- Running the economizer
       SET ECON_OP = True, !- <none>
-      IF OATmp > "+name_cut(econ_choice)+"MASetPoint1_DL, !- <none>
+      IF OATmp > "+name_cut(econ_choice)+"MASetPoint1_#{$faulttype}, !- <none>
       SET OA_SIGN = 1, !- <none>
       ENDIF, !- <none>
     "
@@ -439,13 +439,13 @@ def econ_ductleakage_ems_main_body(workspace, controlleroutdoorair, leak_ratio, 
     end
     if controlleroutdoorair.getString(21).to_s.eql?("Yes")  #High humidity control check
       main_body = main_body+"
-        IF ZoneHumidLOAD"+name_cut(econ_choice)+"_DL < 0.0, !- High Humidity Control
+        IF ZoneHumidLOAD"+name_cut(econ_choice)+"_#{$faulttype} < 0.0, !- High Humidity Control
         SET HIGHHUMCTRL = True, !- <none>
         ENDIF, !- <none>
       "
       if controlleroutdoorair.getString(24).to_s.eql?("Yes")  #Control High Indoor Humidity Based on Outdoor Humidity Ratio
         main_body = main_body+"
-          IF ZoneHumid"+name_cut(econ_choice)+"_DL <= OAHumRat, !- Control High Indoor Humidity Based on Outdoor Humidity Ratio
+          IF ZoneHumid"+name_cut(econ_choice)+"_#{$faulttype} <= OAHumRat, !- Control High Indoor Humidity Based on Outdoor Humidity Ratio
           SET HIGHHUMCTRL = False, !- Set it back to False
           ENDIF, !- <none>
         "
@@ -453,7 +453,7 @@ def econ_ductleakage_ems_main_body(workspace, controlleroutdoorair, leak_ratio, 
     end
     if not controlleroutdoorair.getString(20).to_s.eql?("")  #Time of Day Economizer Control Schedule Name
       main_body = main_body+"
-        SET ECON_FLOW_SCH_VAL = ECONCTRL"+name_cut(econ_choice)+"_SCH_DL, !- <none>
+        SET ECON_FLOW_SCH_VAL = ECONCTRL"+name_cut(econ_choice)+"_SCH_#{$faulttype}, !- <none>
         IF ECON_FLOW_SCH_VAL > 0, !- <none>
         SET OA_SIGN = 1.0, !- <none>
         SET ECON_OP = True, !- <none>
@@ -483,17 +483,17 @@ def econ_ductleakage_ems_main_body(workspace, controlleroutdoorair, leak_ratio, 
     IF NIGHTVENT == 0,
     IF OA_SIGN > MIN_FRAC,
     IF OA_SIGN < 1.0,
-    IF MIX_FLOW_GB#{econ_short_name}_DL > SMALLMASSFLOW, !- Check if the duct has airflow
-    SET RETENTH_GB#{econ_short_name}_DL = ORI_RETENTH, !- to simulate feedback control, don't use measurement values
-    SET RETHUMRAT_GB#{econ_short_name}_DL = ORI_RETHumRat, !- to simulate feedback control, don't use measurement values
-    SET OAENTH_GB#{econ_short_name}_DL = ORI_OAENTH, !- to simulate feedback control, don't use measurement values
-    SET OAHUMRAT_GB#{econ_short_name}_DL = ORI_OAHumRat, !- to simulate feedback control, don't use measurement values
-    SET LOWLIMIT_GB#{econ_short_name}_DL = MIN_FRAC, !- <none>
-    SET UPLIMIT_GB#{econ_short_name}_DL = 1, !- <none>
-    SET MIXTEMPSET_GB#{econ_short_name}_DL = "+name_cut(econ_choice)+"MASetPoint1_DL, !-<none>
-    RUN EMSSolveRegulaFalsi_OA_SIGN#{econ_short_name}_DL, !- <none>
-    IF FLAG_GB#{econ_short_name}_DL > 0, !- <none>
-    SET OA_SIGN = SOLN_GB#{econ_short_name}_DL, !- <none>
+    IF MIX_FLOW_GB#{econ_short_name}_#{$faulttype} > SMALLMASSFLOW, !- Check if the duct has airflow
+    SET RETENTH_GB#{econ_short_name}_#{$faulttype} = ORI_RETENTH, !- to simulate feedback control, don't use measurement values
+    SET RETHUMRAT_GB#{econ_short_name}_#{$faulttype} = ORI_RETHumRat, !- to simulate feedback control, don't use measurement values
+    SET OAENTH_GB#{econ_short_name}_#{$faulttype} = ORI_OAENTH, !- to simulate feedback control, don't use measurement values
+    SET OAHUMRAT_GB#{econ_short_name}_#{$faulttype} = ORI_OAHumRat, !- to simulate feedback control, don't use measurement values
+    SET LOWLIMIT_GB#{econ_short_name}_#{$faulttype} = MIN_FRAC, !- <none>
+    SET UPLIMIT_GB#{econ_short_name}_#{$faulttype} = 1, !- <none>
+    SET MIXTEMPSET_GB#{econ_short_name}_#{$faulttype} = "+name_cut(econ_choice)+"MASetPoint1_#{$faulttype}, !-<none>
+    RUN EMSSolveRegulaFalsi_OA_SIGN#{econ_short_name}_#{$faulttype}, !- <none>
+    IF FLAG_GB#{econ_short_name}_#{$faulttype} > 0, !- <none>
+    SET OA_SIGN = SOLN_GB#{econ_short_name}_#{$faulttype}, !- <none>
     ENDIF,
     ENDIF,
     ENDIF,
@@ -513,10 +513,10 @@ def econ_ductleakage_ems_main_body(workspace, controlleroutdoorair, leak_ratio, 
   if controlleroutdoorair.getString(21).to_s.eql?("Yes")  #High humidity control check
     main_body = main_body+"
       IF HIGHHUMCTRL == True, !- high humidity control
-      SET MIX_FLOW_GB#{econ_short_name}_DL = "+name_cut(econ_choice)+"MixAirFlow_CTRL_DL, !- <none>
+      SET MIX_FLOW_GB#{econ_short_name}_#{$faulttype} = "+name_cut(econ_choice)+"MixAirFlow_CTRL_#{$faulttype}, !- <none>
       SET OA_SIGN_CAN = "+controlleroutdoorair.getString(23).to_s+", !- <none>
       SET OA_SIGN_CAN = OA_SIGN_CAN*MDOT_OA_MAX, !- <none>
-      SET OA_SIGN_CAN = OA_SIGN_CAN/MIX_FLOW_GB#{econ_short_name}_DL, !- <none>
+      SET OA_SIGN_CAN = OA_SIGN_CAN/MIX_FLOW_GB#{econ_short_name}_#{$faulttype}, !- <none>
       SET OA_SIGN = @MAX OA_SIGN_CAN MIN_FRAC, !- <none>
       ENDIF,
     "
@@ -539,12 +539,12 @@ def econ_ductleakage_ems_main_body(workspace, controlleroutdoorair, leak_ratio, 
   
   if not controlleroutdoorair.getString(17).to_s.eql?("")  #Minimum Fraction of Outdoor Air Schedule Name
     main_body = main_body+"
-      SET MIN_SCH_VALUE = "+name_cut(econ_choice)+"_MIN_FRAC_SCH_DL, !- <none>
+      SET MIN_SCH_VALUE = "+name_cut(econ_choice)+"_MIN_FRAC_SCH_#{$faulttype}, !- <none>
       SET MIN_SCH_VALUE = @Max MIN_SCH_VALUE 0.0, !- <none>
       SET MIN_SCH_VALUE = @Min MIN_SCH_VALUE 1.0, !- <none>
       IF MIN_SCH_VALUE > MIN_FRAC, !- <none>
       SET MIN_FRAC = MIN_SCH_VALUE, !- <none>
-      SET MDOT_OA_MIN = MIN_FRAC*MIX_FLOW_GB#{econ_short_name}_DL, !- <none>
+      SET MDOT_OA_MIN = MIN_FRAC*MIX_FLOW_GB#{econ_short_name}_#{$faulttype}, !- <none>
       ENDIF, !- <none>
       SET OA_SIGN = @Max OA_SIGN MIN_FRAC, !- <none>
     "
@@ -552,12 +552,12 @@ def econ_ductleakage_ems_main_body(workspace, controlleroutdoorair, leak_ratio, 
   
   if not controlleroutdoorair.getString(18).to_s.eql?("")  #Maximum Fraction of Outdoor Air Schedule Name
     main_body = main_body+"
-      SET MAX_SCH_VALUE = "+name_cut(econ_choice)+"_MAX_FRAC_SCH_DL, !- <none>
+      SET MAX_SCH_VALUE = "+name_cut(econ_choice)+"_MAX_FRAC_SCH_#{$faulttype}, !- <none>
       SET MAX_SCH_VALUE = @Max MAX_SCH_VALUE 0.0, !- <none>
       SET MAX_SCH_VALUE = @Min MAX_SCH_VALUE 1.0, !- <none>
       IF MIN_FRAC > MAX_SCH_VALUE, !- <none>
       SET MIN_FRAC = MAX_SCH_VALUE, !- <none>
-      SET MDOT_OA_MIN = MIN_FRAC*MIX_FLOW_GB#{econ_short_name}_DL, !- <none>
+      SET MDOT_OA_MIN = MIN_FRAC*MIX_FLOW_GB#{econ_short_name}_#{$faulttype}, !- <none>
       ENDIF, !- <none>
       SET OA_SIGN = @Min OA_SIGN MAX_SCH_VALUE, !- <none>
     "
@@ -565,14 +565,14 @@ def econ_ductleakage_ems_main_body(workspace, controlleroutdoorair, leak_ratio, 
   
   #calculate the outdoor airflow rate
   main_body = main_body+"
-    SET FinalFlow = OA_SIGN*MIX_FLOW_GB#{econ_short_name}_DL, !- <none>
+    SET FinalFlow = OA_SIGN*MIX_FLOW_GB#{econ_short_name}_#{$faulttype}, !- <none>
   "
   
   #make sure that it doesn't exceed the limits of ventilation
   if not controlleroutdoorair.getString(19).to_s.eql?("")
     main_body = main_body+"
       IF OA_MECH > FinalFlow, !- <none>
-      SET FinalFlow = @Min OA_MECH MIX_FLOW_GB#{econ_short_name}_DL, !- <none>
+      SET FinalFlow = @Min OA_MECH MIX_FLOW_GB#{econ_short_name}_#{$faulttype}, !- <none>
       ENDIF, !- <none>
     "
   end
@@ -592,7 +592,7 @@ def econ_ductleakage_ems_main_body(workspace, controlleroutdoorair, leak_ratio, 
   #check with mixed airflow
   main_body = main_body+"
     SET OA_NEW = FinalFlow, !- <none>
-    SET OA_NEW = @Min OA_NEW MIX_FLOW_GB#{econ_short_name}_DL, !- <none>
+    SET OA_NEW = @Min OA_NEW MIX_FLOW_GB#{econ_short_name}_#{$faulttype}, !- <none>
     SET FinalFlow = OA_NEW, !- <none>
   "
   
@@ -608,7 +608,7 @@ def econ_ductleakage_ems_main_body(workspace, controlleroutdoorair, leak_ratio, 
     SET OA_NEW = @Min MDOT_OA_MAX OA_NEW, !- <none>
     SET FinalFlow = OA_NEW, !- <none>
     ENDIF, !- <none>
-    SET "+name_cut(econ_choice)+"MDOT_OA = FinalFlow + ("+name_cut(econ_choice)+"MixAirFlow_CTRL_DL - FinalFlow)*("+leakratio+")*AF_current_#{$faulttype}_#{oacontrollername}; !- <none>
+    SET "+name_cut(econ_choice)+"MDOT_OA_#{$faulttype} = FinalFlow + ("+name_cut(econ_choice)+"MixAirFlow_CTRL_#{$faulttype} - FinalFlow)*("+leakratio+")*AF_current_#{$faulttype}_#{oacontrollername}; !- <none>
   "
   
   return main_body
@@ -726,17 +726,17 @@ def econ_ductleakage_ems_other(string_objects, workspace, controlleroutdoorair)
   
   string_objects << "
     EnergyManagementSystem:Subroutine,
-      RES_OA_SIGN#{econ_short_name}_DL, !- Name
-      SET TEMP_OA_SIGN = OA_SIGN_GB#{econ_short_name}_DL, !- <none>
-      SET TEMP_MIX_FLOW = MIX_FLOW_GB#{econ_short_name}_DL, !- <none>
+      RES_OA_SIGN#{econ_short_name}_#{$faulttype}, !- Name
+      SET TEMP_OA_SIGN = OA_SIGN_GB#{econ_short_name}_#{$faulttype}, !- <none>
+      SET TEMP_MIX_FLOW = MIX_FLOW_GB#{econ_short_name}_#{$faulttype}, !- <none>
       SET TEMP_OA_FLOW = TEMP_OA_SIGN*TEMP_MIX_FLOW, !- <none>
       SET RECFLOW1 = 0, !- <none>
       SET RECFLOW2 = TEMP_MIX_FLOW-TEMP_OA_FLOW, !- <none>
       SET RECIR_FLOW = @MAX RECFLOW1 RECFLOW2, !- <none>
-      SET TEMP_RETENTH = RETENTH_GB#{econ_short_name}_DL, !- <none>
-      SET TEMP_RETHUMRAT = RETHUMRAT_GB#{econ_short_name}_DL, !- <none>
-      SET TEMP_OAENTH = OAENTH_GB#{econ_short_name}_DL, !- <none>
-      SET TEMP_OAHUMRAT = OAHUMRAT_GB#{econ_short_name}_DL, !- <none>
+      SET TEMP_RETENTH = RETENTH_GB#{econ_short_name}_#{$faulttype}, !- <none>
+      SET TEMP_RETHUMRAT = RETHUMRAT_GB#{econ_short_name}_#{$faulttype}, !- <none>
+      SET TEMP_OAENTH = OAENTH_GB#{econ_short_name}_#{$faulttype}, !- <none>
+      SET TEMP_OAHUMRAT = OAHUMRAT_GB#{econ_short_name}_#{$faulttype}, !- <none>
       SET TEMP_MIXENTH = RECIR_FLOW*TEMP_RETENTH, !- <none>
       SET TEMP_MIXENTH = TEMP_MIXENTH+TEMP_OA_FLOW*TEMP_OAENTH, !- <none>
       SET TEMP_MIXENTH = TEMP_MIXENTH/TEMP_MIX_FLOW, !- <none>
@@ -744,23 +744,23 @@ def econ_ductleakage_ems_other(string_objects, workspace, controlleroutdoorair)
       SET TEMP_MIXHUMRAT = TEMP_MIXHUMRAT+TEMP_OA_FLOW*TEMP_OAHUMRAT, !- <none>
       SET TEMP_MIXHUMRAT = TEMP_MIXHUMRAT/TEMP_MIX_FLOW, !- <none>
       SET TEMP_MIXTEMP = @TdbFnHW TEMP_MIXENTH TEMP_MIXHUMRAT, !- <none>
-      SET TEMP_AA = MIXTEMPSET_GB#{econ_short_name}_DL-TEMP_MIXTEMP, !- <none>
-      SET RESIDUAL_GB#{econ_short_name}_DL = TEMP_AA; !- <none>
+      SET TEMP_AA = MIXTEMPSET_GB#{econ_short_name}_#{$faulttype}-TEMP_MIXTEMP, !- <none>
+      SET RESIDUAL_GB#{econ_short_name}_#{$faulttype} = TEMP_AA; !- <none>
   "
   
   string_objects << "
     EnergyManagementSystem:Subroutine,
-      EMSSolveRegulaFalsi_OA_SIGN#{econ_short_name}_DL, !- Name
-      SET OA_SIGN_GB#{econ_short_name}_DL = LOWLIMIT_GB#{econ_short_name}_DL, !- <none>
-      RUN RES_OA_SIGN#{econ_short_name}_DL, !- <none>
-      SET Y0 = RESIDUAL_GB#{econ_short_name}_DL, !- <none>
-      SET OA_SIGN_GB#{econ_short_name}_DL = UPLIMIT_GB#{econ_short_name}_DL, !- <none>
-      RUN RES_OA_SIGN#{econ_short_name}_DL, !- <none>
-      SET Y1 = RESIDUAL_GB#{econ_short_name}_DL, !- <none>
+      EMSSolveRegulaFalsi_OA_SIGN#{econ_short_name}_#{$faulttype}, !- Name
+      SET OA_SIGN_GB#{econ_short_name}_#{$faulttype} = LOWLIMIT_GB#{econ_short_name}_#{$faulttype}, !- <none>
+      RUN RES_OA_SIGN#{econ_short_name}_#{$faulttype}, !- <none>
+      SET Y0 = RESIDUAL_GB#{econ_short_name}_#{$faulttype}, !- <none>
+      SET OA_SIGN_GB#{econ_short_name}_#{$faulttype} = UPLIMIT_GB#{econ_short_name}_#{$faulttype}, !- <none>
+      RUN RES_OA_SIGN#{econ_short_name}_#{$faulttype}, !- <none>
+      SET Y1 = RESIDUAL_GB#{econ_short_name}_#{$faulttype}, !- <none>
       SET PROD = Y0*Y1, !- <none>
       IF Y0*Y1 > 0, !- <none>
-      SET FLAG_GB#{econ_short_name}_DL = -2, !- <none>
-      SET SOLN_GB#{econ_short_name}_DL = LOWLIMIT_GB#{econ_short_name}_DL, !- <none>
+      SET FLAG_GB#{econ_short_name}_#{$faulttype} = -2, !- <none>
+      SET SOLN_GB#{econ_short_name}_#{$faulttype} = LOWLIMIT_GB#{econ_short_name}_#{$faulttype}, !- <none>
       RETURN, ! Error for solution
       ENDIF, !- <none>
       SET CONT = 1, !- <none>
@@ -774,11 +774,11 @@ def econ_ductleakage_ems_other(string_objects, workspace, controlleroutdoorair)
       SET DY = 1.d-10, !- <none>
       ENDIF, !- <none>
       ENDIF, !- <none>
-      SET XTemp = Y0*UPLIMIT_GB#{econ_short_name}_DL, !- <none>
-      SET XTemp = (XTemp-Y1*LOWLIMIT_GB#{econ_short_name}_DL)/DY, !- <none>
-      SET OA_SIGN_GB#{econ_short_name}_DL = XTemp, !- <none>
-      RUN RES_OA_SIGN#{econ_short_name}_DL, !- <none>
-      SET YTemp = RESIDUAL_GB#{econ_short_name}_DL, !- <none>
+      SET XTemp = Y0*UPLIMIT_GB#{econ_short_name}_#{$faulttype}, !- <none>
+      SET XTemp = (XTemp-Y1*LOWLIMIT_GB#{econ_short_name}_#{$faulttype})/DY, !- <none>
+      SET OA_SIGN_GB#{econ_short_name}_#{$faulttype} = XTemp, !- <none>
+      RUN RES_OA_SIGN#{econ_short_name}_#{$faulttype}, !- <none>
+      SET YTemp = RESIDUAL_GB#{econ_short_name}_#{$faulttype}, !- <none>
       SET NITE = NITE+1, !- <none>
       IF YTemp < 0.0001 && YTemp+0.0001 > 0, !- <none>
       SET CONT = 0, !- <none>
@@ -789,101 +789,101 @@ def econ_ductleakage_ems_other(string_objects, workspace, controlleroutdoorair)
       IF CONT > 0.0d0, !- <none>
       IF Y0 < 0.0d0, !- <none>
       IF YTemp < 0.0d0, !- <none>
-      SET LOWLIMIT_GB#{econ_short_name}_DL = XTemp, !- <none>
+      SET LOWLIMIT_GB#{econ_short_name}_#{$faulttype} = XTemp, !- <none>
       SET Y0 = YTemp, !- <none>
       ELSE, !- <none>
-      SET UPLIMIT_GB#{econ_short_name}_DL = XTemp, !- <none>
+      SET UPLIMIT_GB#{econ_short_name}_#{$faulttype} = XTemp, !- <none>
       SET Y1 = YTemp, !- <none>
       ENDIF, !- <none>
       ELSE, !- <none>
       IF YTemp < 0.0d0, !- <none>
-      SET UPLIMIT_GB#{econ_short_name}_DL = XTemp, !- <none>
+      SET UPLIMIT_GB#{econ_short_name}_#{$faulttype} = XTemp, !- <none>
       SET Y1 = YTemp, !- <none>
       ELSE, !- <none>
-      SET LOWLIMIT_GB#{econ_short_name}_DL = XTemp, !- <none>
+      SET LOWLIMIT_GB#{econ_short_name}_#{$faulttype} = XTemp, !- <none>
       SET Y0 = YTemp, !- <none>
       ENDIF, !- <none>
       ENDIF, !- <none>
       ENDIF, !- <none>
       ENDWHILE, !- <none>
       IF CONV == 1, !- <none>
-      SET FLAG_GB#{econ_short_name}_DL = NITE, !- <none>
+      SET FLAG_GB#{econ_short_name}_#{$faulttype} = NITE, !- <none>
       ELSE,
-      SET FLAG_GB#{econ_short_name}_DL = -1, !- <none>
+      SET FLAG_GB#{econ_short_name}_#{$faulttype} = -1, !- <none>
       ENDIF, !- <none>
-      SET SOLN_GB#{econ_short_name}_DL = XTemp; !- <none>
+      SET SOLN_GB#{econ_short_name}_#{$faulttype} = XTemp; !- <none>
   "
   
   string_objects << "
     EnergyManagementSystem:ProgramCallingManager,
       EMSCallt_bias"+name_cut(econ_choice)+", !- Name
       InsideHVACSystemIterationLoop,       !- EnergyPlus Model Calling Point
-      t_bias"+name_cut(econ_choice)+"_DL, !- Name
+      t_bias"+name_cut(econ_choice)+"_#{$faulttype}, !- Name
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      RESIDUAL_GB#{econ_short_name}_DL;
+      RESIDUAL_GB#{econ_short_name}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      LOWLIMIT_GB#{econ_short_name}_DL;
+      LOWLIMIT_GB#{econ_short_name}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      UPLIMIT_GB#{econ_short_name}_DL;
+      UPLIMIT_GB#{econ_short_name}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      FLAG_GB#{econ_short_name}_DL;
+      FLAG_GB#{econ_short_name}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      SOLN_GB#{econ_short_name}_DL;
+      SOLN_GB#{econ_short_name}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      OA_SIGN_GB#{econ_short_name}_DL;
+      OA_SIGN_GB#{econ_short_name}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      MIX_FLOW_GB#{econ_short_name}_DL;
+      MIX_FLOW_GB#{econ_short_name}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      RETENTH_GB#{econ_short_name}_DL;
+      RETENTH_GB#{econ_short_name}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      RETHUMRAT_GB#{econ_short_name}_DL;
+      RETHUMRAT_GB#{econ_short_name}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      OAENTH_GB#{econ_short_name}_DL;
+      OAENTH_GB#{econ_short_name}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      OAHUMRAT_GB#{econ_short_name}_DL;
+      OAHUMRAT_GB#{econ_short_name}_#{$faulttype};
   "
   
   string_objects << "      
     EnergyManagementSystem:GlobalVariable,
-      MIXTEMPSET_GB#{econ_short_name}_DL;
+      MIXTEMPSET_GB#{econ_short_name}_#{$faulttype};
   "
   
   string_objects << "   
     EnergyManagementSystem:Actuator,
-      "+name_cut(econ_choice)+"MDOT_OA_DL,        !- Name
+      "+name_cut(econ_choice)+"MDOT_OA_#{$faulttype},        !- Name
       "+econ_choice+", !- Actuated Component Unique Name
       Outdoor Air Controller,                                  !- Actuated Component Type
       Air Mass Flow Rate;                           !- Actuated Component Control Type
@@ -920,35 +920,35 @@ def econ_ductleakage_ems_other(string_objects, workspace, controlleroutdoorair)
   
   string_objects << "
     EnergyManagementSystem:InternalVariable,
-      DesAirflow"+name_cut(econ_choice)+"_DL,
+      DesAirflow"+name_cut(econ_choice)+"_#{$faulttype},
       "+airsystem_name+",
       Intermediate Air System Main Supply Volume Flow Rate;
   "
   
   string_objects << "
     EnergyManagementSystem:InternalVariable,
-      CMDesAirflow"+name_cut(econ_choice)+"_DL,
+      CMDesAirflow"+name_cut(econ_choice)+"_#{$faulttype},
       "+airsystem_name+",
       Intermediate Air System "+sizing_option+" Peak Cooling Mass Flow Rate;
   "
   
   string_objects << "
     EnergyManagementSystem:InternalVariable,
-      HMDesAirflow"+name_cut(econ_choice)+"_DL,
+      HMDesAirflow"+name_cut(econ_choice)+"_#{$faulttype},
       "+airsystem_name+",
       Intermediate Air System "+sizing_option+" Peak Heating Mass Flow Rate;
   "
   
   string_objects << "
     EnergyManagementSystem:InternalVariable,
-      MinOAMdot"+name_cut(econ_choice)+"_DL,
+      MinOAMdot"+name_cut(econ_choice)+"_#{$faulttype},
       "+econ_choice+",
       Outdoor Air Controller Minimum Mass Flow Rate;
   "
   
   string_objects << "
     EnergyManagementSystem:InternalVariable,
-      MaxOAMdot"+name_cut(econ_choice)+"_DL,
+      MaxOAMdot"+name_cut(econ_choice)+"_#{$faulttype},
       "+econ_choice+",
       Outdoor Air Controller Maximum Mass Flow Rate;
   "
@@ -974,25 +974,25 @@ def econ_ductleakage_ems_other(string_objects, workspace, controlleroutdoorair)
               zone_name_tag = name_cut(zone_name)
               string_objects << "
                 EnergyManagementSystem:InternalVariable,
-                  "+zone_name_tag+"_VOL_DL,
+                  "+zone_name_tag+"_VOL_#{$faulttype},
                   "+zone_name+",
                   Zone Air Volume;
               "
               string_objects << "
                 EnergyManagementSystem:InternalVariable,
-                  "+zone_name_tag+"_MUL_DL,
+                  "+zone_name_tag+"_MUL_#{$faulttype},
                   "+zone_name+",
                   Zone Multiplier;
               "
               string_objects << "
                 EnergyManagementSystem:InternalVariable,
-                  "+zone_name_tag+"_LIST_MUL_DL,
+                  "+zone_name_tag+"_LIST_MUL_#{$faulttype},
                   "+zone_name+",
                   Zone List Multiplier;
               "
               string_objects << "
                 EnergyManagementSystem:InternalVariable,
-                  "+zone_name_tag+"_AREA_DL,
+                  "+zone_name_tag+"_AREA_#{$faulttype},
                   "+zone_name+",
                   Zone Floor Area;
               "
@@ -1002,7 +1002,7 @@ def econ_ductleakage_ems_other(string_objects, workspace, controlleroutdoorair)
 				  people_name = people.getString(0).to_s
 				  string_objects << "
                     EnergyManagementSystem:Sensor,
-                    "+zone_name_tag+"_PEOPLE#{bias_sensor}_T, !- Name
+                    "+zone_name_tag+"_PEOPLE#{bias_sensor}_T_#{$faulttype}, !- Name
                     "+people_name+",                        !- Output:Variable or Output:Meter Index Key Name
                     Zone People Occupant Count;                !- Output:Variable or Output:Meter Name
                   "
@@ -1011,7 +1011,7 @@ def econ_ductleakage_ems_other(string_objects, workspace, controlleroutdoorair)
 			  #####################################################
               string_objects << "
                 EnergyManagementSystem:Sensor,
-                  "+zone_name_tag+"_OA_SCH_DL, !- Name
+                  "+zone_name_tag+"_OA_SCH_#{$faulttype}, !- Name
                   "+oaschedule_name+",                        !- Output:Variable or Output:Meter Index Key Name
                   Schedule Value;                !- Output:Variable or Output:Meter Name
               "
@@ -1024,14 +1024,14 @@ def econ_ductleakage_ems_other(string_objects, workspace, controlleroutdoorair)
   
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(airsystem_name)+"_Htg_DL,
+      "+name_cut(airsystem_name)+"_Htg_#{$faulttype},
       "+airsystem_name+",
       Air System Heating Coil Total Heating Energy;
   "
   
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(airsystem_name)+"_Ctg_DL,
+      "+name_cut(airsystem_name)+"_Ctg_#{$faulttype},
       "+airsystem_name+",
       Air System Cooling Coil Total Cooling Energy;
   "
@@ -1039,21 +1039,21 @@ def econ_ductleakage_ems_other(string_objects, workspace, controlleroutdoorair)
   ret_node_name = controlleroutdoorair.getString(2).to_s
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(econ_choice)+"RETTemp1_DL,  !- Name
+      "+name_cut(econ_choice)+"RETTemp1_#{$faulttype},  !- Name
       "+ret_node_name+",                        !- Output:Variable or Output:Meter Index Key Name
       System Node Temperature;                !- Output:Variable or Output:Meter Name
   "
   
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(econ_choice)+"RETOmega1_DL,  !- Name
+      "+name_cut(econ_choice)+"RETOmega1_#{$faulttype},  !- Name
       "+ret_node_name+",                        !- Output:Variable or Output:Meter Index Key Name
       System Node Humidity Ratio;                !- Output:Variable or Output:Meter Name
   "
   
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(econ_choice)+"RETPressure1_DL,  !- Name
+      "+name_cut(econ_choice)+"RETPressure1_#{$faulttype},  !- Name
       "+ret_node_name+",                        !- Output:Variable or Output:Meter Index Key Name
       System Node Pressure;                !- Output:Variable or Output:Meter Name
   "
@@ -1061,7 +1061,7 @@ def econ_ductleakage_ems_other(string_objects, workspace, controlleroutdoorair)
   mx_node_name = controlleroutdoorair.getString(3).to_s
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(econ_choice)+"MASetPoint1_DL,  !- Name
+      "+name_cut(econ_choice)+"MASetPoint1_#{$faulttype},  !- Name
       "+mx_node_name+",                        !- Output:Variable or Output:Meter Index Key Name
       System Node Setpoint Temperature;                !- Output:Variable or Output:Meter Name
   "
@@ -1069,21 +1069,21 @@ def econ_ductleakage_ems_other(string_objects, workspace, controlleroutdoorair)
   oa_node_name = controlleroutdoorair.getString(4).to_s
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(econ_choice)+"OATTemp1_DL,  !- Name
+      "+name_cut(econ_choice)+"OATTemp1_#{$faulttype},  !- Name
       "+oa_node_name+",                        !- Output:Variable or Output:Meter Index Key Name
       System Node Temperature;                !- Output:Variable or Output:Meter Name
   "
   
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(econ_choice)+"OATOmega1_DL,  !- Name
+      "+name_cut(econ_choice)+"OATOmega1_#{$faulttype},  !- Name
       "+oa_node_name+",                        !- Output:Variable or Output:Meter Index Key Name
       System Node Humidity Ratio;                !- Output:Variable or Output:Meter Name
   "
   
   string_objects << "
     EnergyManagementSystem:Sensor,
-      "+name_cut(econ_choice)+"MixAirFlow_CTRL_DL,  !- Name
+      "+name_cut(econ_choice)+"MixAirFlow_CTRL_#{$faulttype},  !- Name
       "+airsystem_name+",                        !- Output:Variable or Output:Meter Index Key Name
       Air System Mixed Air Mass Flow Rate;                !- Output:Variable or Output:Meter Name
   "
@@ -1094,7 +1094,7 @@ def econ_ductleakage_ems_other(string_objects, workspace, controlleroutdoorair)
     # check high humidity control before adding
     string_objects << "
       EnergyManagementSystem:Sensor,
-        ZoneHumid"+name_cut(econ_choice)+"_DL,  !- Name
+        ZoneHumid"+name_cut(econ_choice)+"_#{$faulttype},  !- Name
         "+humidistat_zone+",                        !- Output:Variable or Output:Meter Index Key Name
         Zone Air Humidity Ratio;                !- Output:Variable or Output:Meter Name
     "
@@ -1102,7 +1102,7 @@ def econ_ductleakage_ems_other(string_objects, workspace, controlleroutdoorair)
     # check high humidity control before adding
     string_objects << "
       EnergyManagementSystem:Sensor,
-        ZoneHumidLOAD"+name_cut(econ_choice)+"_DL,  !- Name
+        ZoneHumidLOAD"+name_cut(econ_choice)+"_#{$faulttype},  !- Name
         "+humidistat_zone+",                        !- Output:Variable or Output:Meter Index Key Name
         Zone Predicted Moisture Load to Humidifying Setpoint Moisture Transfer Rate;                !- Output:Variable or Output:Meter Name
     "
@@ -1112,7 +1112,7 @@ def econ_ductleakage_ems_other(string_objects, workspace, controlleroutdoorair)
   if not controlleroutdoorair.getString(20).to_s.eql?("")
     string_objects << "
       EnergyManagementSystem:Sensor,
-        ECONCTRL"+name_cut(econ_choice)+"_SCH_DL, !- Name
+        ECONCTRL"+name_cut(econ_choice)+"_SCH_#{$faulttype}, !- Name
         "+controlleroutdoorair.getString(20).to_s+", !- Schedule Name
         Schedule Value; !- Output:Variable
     "
@@ -1122,7 +1122,7 @@ def econ_ductleakage_ems_other(string_objects, workspace, controlleroutdoorair)
   if false
     string_objects << "
       EnergyManagementSystem:Sensor,
-        NIGHTVENT_SCH_DL, !- Name
+        NIGHTVENT_SCH_#{$faulttype}, !- Name
         [Schedule name from Ruby], !- Schedule Name
         Schedule Value; !- Output:Variable
     "
@@ -1132,7 +1132,7 @@ def econ_ductleakage_ems_other(string_objects, workspace, controlleroutdoorair)
   if not controlleroutdoorair.getString(18).to_s.eql?("")
     string_objects << "
       EnergyManagementSystem:Sensor,
-        "+name_cut(econ_choice)+"_MAX_FRAC_SCH_DL, !- Name
+        "+name_cut(econ_choice)+"_MAX_FRAC_SCH_#{$faulttype}, !- Name
         "+controlleroutdoorair.getString(18).to_s+", !- Schedule Name
         Schedule Value; !- Output:Variable
     "
@@ -1142,7 +1142,7 @@ def econ_ductleakage_ems_other(string_objects, workspace, controlleroutdoorair)
   if not controlleroutdoorair.getString(16).to_s.eql?("")
     string_objects << "
       EnergyManagementSystem:Sensor,
-        "+name_cut(econ_choice)+"_MIN_SCH_DL, !- Name
+        "+name_cut(econ_choice)+"_MIN_SCH_#{$faulttype}, !- Name
         "+controlleroutdoorair.getString(16).to_s+", !- Schedule Name
         Schedule Value; !- Output:Variable
     "
@@ -1152,7 +1152,7 @@ def econ_ductleakage_ems_other(string_objects, workspace, controlleroutdoorair)
   if not controlleroutdoorair.getString(17).to_s.eql?("")
     string_objects << "
       EnergyManagementSystem:Sensor,
-        "+name_cut(econ_choice)+"_MIN_FRAC_SCH_DL, !- Name
+        "+name_cut(econ_choice)+"_MIN_FRAC_SCH_#{$faulttype}, !- Name
         "+controlleroutdoorair.getString(17).to_s+", !- Schedule Name
         Schedule Value; !- Output:Variable
     "


### PR DESCRIPTION
major mod includes modifications on biased economizer sensor fault models (OAT, OARH, RAT, RARH)

#NOTE: modifications were made to fix zone_ppl calculation issue when "ZoneList" object is used instead of "Zone" object in the internal gain "People" object. this resulted in difference in minimum outdoor air flow rate.

#TODO: there is still slight different in minimum outdoor air flow rate calculation between baseline (without fault model) model and faulted (fault model with FI = 0) model.