### PR TITLE
AHU fan motor degradation fault model default argument update

### DIFF
--- a/fault_measures_2017/AirHandlingUnitFanMotorDegradation/measure.rb
+++ b/fault_measures_2017/AirHandlingUnitFanMotorDegradation/measure.rb
@@ -78,7 +78,7 @@ class AirHandlingUnitFanMotorDegradation < OpenStudio::Ruleset::WorkspaceUserScr
 	#make a double argument for the start month
     start_month = OpenStudio::Ruleset::OSArgument::makeDoubleArgument('start_month', false)
     start_month.setDisplayName('Enter the month (1-12) when the fault starts to occur')
-    start_month.setDefaultValue(6)  #default is June
+    start_month.setDefaultValue(1)  #default is June
     args << start_month
 	
 	#make a double argument for the start date
@@ -90,7 +90,7 @@ class AirHandlingUnitFanMotorDegradation < OpenStudio::Ruleset::WorkspaceUserScr
 	#make a double argument for the start time
     start_time = OpenStudio::Ruleset::OSArgument::makeDoubleArgument('start_time', false)
     start_time.setDisplayName('Enter the time of day (0-24) when the fault starts to occur')
-    start_time.setDefaultValue(9)  #default is 9am
+    start_time.setDefaultValue(0)  #default is 9am
     args << start_time
 	
 	#make a double argument for the end month

--- a/fault_measures_2017/BiasedEconomizerSensorOutdoorT/measure.xml
+++ b/fault_measures_2017/BiasedEconomizerSensorOutdoorT/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>biased_economizer_sensor_oat</name>
   <uid>75ad65c1-1f17-4fa3-be05-13a3bb415fbe</uid>
-  <version_id>f8ea38e0-9f84-42a6-bbcf-16b2c291cd11</version_id>
-  <version_modified>20190415T164118Z</version_modified>
+  <version_id>ef6ea353-51e2-45b5-a3ff-de38aa1f94c3</version_id>
+  <version_modified>20190524T222306Z</version_modified>
   <xml_checksum>B7427881</xml_checksum>
   <class_name>BiasedEconomizerSensorOAT</class_name>
   <display_name>Biased Economizer Sensor: Outdoor Temperature</display_name>


### PR DESCRIPTION
Default arguments related to "fault evolution" updated. And now by default the fault is present for the entire year (before it only started from JUN to DEC).