### PR TITLE
Biased economizer sensor fault update

### DIFF
--- a/fault_measures_2017/AirHandlingUnitFanMotorDegradation/measure.xml
+++ b/fault_measures_2017/AirHandlingUnitFanMotorDegradation/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>air_handling_unit_fan_motor_degradation</name>
   <uid>9814a5e9-37b7-472a-bae5-e9e2e794c024</uid>
-  <version_id>65672ee8-3281-498c-81cf-63c238394bb4</version_id>
-  <version_modified>20190306T224821Z</version_modified>
+  <version_id>eb1fb0ba-a74c-4ae0-82c1-ea75b319dfdd</version_id>
+  <version_modified>20190531T185507Z</version_modified>
   <xml_checksum>FAAEB4D1</xml_checksum>
   <class_name>AirHandlingUnitFanMotorDegradation</class_name>
   <display_name>Air Handling Unit Fan Motor Degradation</display_name>

--- a/fault_measures_2017/BiasedEconomizerSensorOutdoorT/measure.xml
+++ b/fault_measures_2017/BiasedEconomizerSensorOutdoorT/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>biased_economizer_sensor_oat</name>
   <uid>75ad65c1-1f17-4fa3-be05-13a3bb415fbe</uid>
-  <version_id>aea2676b-b2ec-459e-b60a-ffca52216cb2</version_id>
-  <version_modified>20190604T155455Z</version_modified>
+  <version_id>c8fa3f10-7db9-4a15-afb9-cb8b2ac3f1ed</version_id>
+  <version_modified>20190605T142000Z</version_modified>
   <xml_checksum>B7427881</xml_checksum>
   <class_name>BiasedEconomizerSensorOAT</class_name>
   <display_name>Biased Economizer Sensor: Outdoor Temperature</display_name>
@@ -117,6 +117,12 @@
       <checksum>435C6B82</checksum>
     </file>
     <file>
+      <filename>ControllerOutdoorAirFlow_T.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>1E151538</checksum>
+    </file>
+    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>1.5.0</identifier>
@@ -125,13 +131,7 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>F7471DDE</checksum>
-    </file>
-    <file>
-      <filename>ControllerOutdoorAirFlow_T.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>1E151538</checksum>
+      <checksum>F4420CED</checksum>
     </file>
   </files>
 </measure>

--- a/fault_measures_2017/BiasedEconomizerSensorOutdoorT/measure.xml
+++ b/fault_measures_2017/BiasedEconomizerSensorOutdoorT/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>biased_economizer_sensor_oat</name>
   <uid>75ad65c1-1f17-4fa3-be05-13a3bb415fbe</uid>
-  <version_id>f8ea38e0-9f84-42a6-bbcf-16b2c291cd11</version_id>
-  <version_modified>20190415T164118Z</version_modified>
+  <version_id>79293725-d947-4ae5-9e4f-26966c0b6193</version_id>
+  <version_modified>20190531T223722Z</version_modified>
   <xml_checksum>B7427881</xml_checksum>
   <class_name>BiasedEconomizerSensorOAT</class_name>
   <display_name>Biased Economizer Sensor: Outdoor Temperature</display_name>
@@ -117,12 +117,6 @@
       <checksum>435C6B82</checksum>
     </file>
     <file>
-      <filename>ControllerOutdoorAirFlow_T.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>resource</usage_type>
-      <checksum>E7FE2EC1</checksum>
-    </file>
-    <file>
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>1.5.0</identifier>
@@ -132,6 +126,12 @@
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
       <checksum>F4420CED</checksum>
+    </file>
+    <file>
+      <filename>ControllerOutdoorAirFlow_T.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>2CCB8C1D</checksum>
     </file>
   </files>
 </measure>

--- a/fault_measures_2017/BiasedEconomizerSensorOutdoorT/measure.xml
+++ b/fault_measures_2017/BiasedEconomizerSensorOutdoorT/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>biased_economizer_sensor_oat</name>
   <uid>75ad65c1-1f17-4fa3-be05-13a3bb415fbe</uid>
-  <version_id>79293725-d947-4ae5-9e4f-26966c0b6193</version_id>
-  <version_modified>20190531T223722Z</version_modified>
+  <version_id>aea2676b-b2ec-459e-b60a-ffca52216cb2</version_id>
+  <version_modified>20190604T155455Z</version_modified>
   <xml_checksum>B7427881</xml_checksum>
   <class_name>BiasedEconomizerSensorOAT</class_name>
   <display_name>Biased Economizer Sensor: Outdoor Temperature</display_name>
@@ -125,13 +125,13 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>F4420CED</checksum>
+      <checksum>F7471DDE</checksum>
     </file>
     <file>
       <filename>ControllerOutdoorAirFlow_T.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>2CCB8C1D</checksum>
+      <checksum>1E151538</checksum>
     </file>
   </files>
 </measure>

--- a/fault_measures_2017/BiasedEconomizerSensorOutdoorT/resources/ControllerOutdoorAirFlow_T.rb
+++ b/fault_measures_2017/BiasedEconomizerSensorOutdoorT/resources/ControllerOutdoorAirFlow_T.rb
@@ -181,7 +181,8 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
     main_body = main_body+"
 	  SET RETTmp = "+name_cut(econ_choice)+"RETTemp1#{bias_sensor}_#{$faulttype}, !- <none>
       SET RETHumRat = "+name_cut(econ_choice)+"RETOmega1#{bias_sensor}_#{$faulttype}, !- <none>
-      SET OATmp = "+name_cut(econ_choice)+"OATTemp1#{bias_sensor}_#{$faulttype}"+oa_str_num+"*AF_current_#{$faulttype}_#{oacontrollername}, !- <none>
+	  SET OATmp_ORI = "+name_cut(econ_choice)+"OATTemp1#{bias_sensor}_#{$faulttype}, !- <none>
+      SET OATmp = OATmp_ORI"+oa_str_num+"*AF_current_#{$faulttype}_#{oacontrollername}, !- <none>
       SET OAHumRat = "+name_cut(econ_choice)+"OATOmega1#{bias_sensor}_#{$faulttype}, !- <none>
       SET PTmp = "+name_cut(econ_choice)+"RETPressure1#{bias_sensor}_#{$faulttype}, !- <none>
       IF PTmp < DELTASMALL, !- <none>
@@ -190,7 +191,7 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
       SET RETRH = @RhFnTdbWPb RETTmp RETHumRat PTmp, !- <none>
       SET ORI_RETENTH = @HFnTdbRhPb RETTmp RETRH PTmp, !- <none>
       SET ORI_RETHumRat = RETHumRat, !- <none>
-      SET ORI_OAENTH = @HFnTdbW OATmp OAHumRat, !- <none>
+      SET ORI_OAENTH = @HFnTdbW OATmp_ORI OAHumRat, !- <none>
       SET ORI_OAHumRat = OAHumRat, !- <none>
 	  SET RETENTH = @HFnTdbRhPb RETTmp RETRH PTmp, !- <none>
       SET RETRHO = @RhoAirFnPbTdbW PTmp RETTmp RETHumRat, !- Calculate density before offsetting because density is not used by the controller

--- a/fault_measures_2017/BiasedEconomizerSensorOutdoorT/resources/ControllerOutdoorAirFlow_T.rb
+++ b/fault_measures_2017/BiasedEconomizerSensorOutdoorT/resources/ControllerOutdoorAirFlow_T.rb
@@ -178,6 +178,7 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
       SET OAENTH = @HFnTdbW OATmp OAHumRat, !- <none>
     "
   elsif bias_sensor.eql?("OA")
+    #########################################################################################################
     main_body = main_body+"
 	  SET RETTmp = "+name_cut(econ_choice)+"RETTemp1#{bias_sensor}_#{$faulttype}, !- <none>
       SET RETHumRat = "+name_cut(econ_choice)+"RETOmega1#{bias_sensor}_#{$faulttype}, !- <none>
@@ -199,6 +200,7 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
 	  SET OAENTH = @HFnTdbRhPb OATmp OARH PTmp, !- <none>
       SET OAHumRat = @WFnTdbH OATmp OAENTH, !- Recalculate humidity ratio after the offset
     "
+	#########################################################################################################
   else  #for bias in both sensors
     main_body = main_body+"
       SET RETTmp = "+name_cut(econ_choice)+"RETTemp1#{bias_sensor}_#{$faulttype}"+ret_str_num+"*AF_current_#{$faulttype}_#{oacontrollername}, !- <none>
@@ -368,7 +370,7 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
       end
     end
   end
-  
+  #########################################################################################################
   main_body = main_body+"
     SET MIN_FRAC = @Max MIN_FRAC 0.0, !- <none>
     SET MIN_FRAC = @Min MIN_FRAC 1.0, !- <none>
@@ -376,15 +378,15 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
     SET TDiff = RETTmp-OATmp, !- <none>
     SET TDiff = @Abs TDiff, !- <none>
     IF TDiff > DELTASMALL, !- <none>
-    SET OA_SIGN = (RETTmp-"+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype})/(RETTmp-OATmp), !- Initialize the signal
+    SET OA_SIGN = (RETTmp-"+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype})/(RETTmp-OATmp_ORI), !- Initialize the signal
     ELSE, !- <none>
-    IF RETTmp < "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype} && RETTmp >= OATmp, !- <none>
+    IF RETTmp < "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype} && RETTmp >= OATmp_ORI, !- <none>
     SET OA_SIGN = -1, !- <none>
-    ELSEIF RETTmp < "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype} && RETTmp < OATmp, !- <none>
+    ELSEIF RETTmp < "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype} && RETTmp < OATmp_ORI, !- <none>
     SET OA_SIGN = 1, !- <none>
-    ELSEIF RETTmp >= "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype} && RETTmp >= OATmp,
+    ELSEIF RETTmp >= "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype} && RETTmp >= OATmp_ORI,
     SET OA_SIGN = 1, !- <none>
-    ELSEIF RETTmp >= "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype} && RETTmp < OATmp,
+    ELSEIF RETTmp >= "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype} && RETTmp < OATmp_ORI,
     SET OA_SIGN = -1, !- <none>
     ENDIF, !- <none>
     ENDIF, !- <none>
@@ -392,6 +394,7 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
     SET OA_SIGN = @Min OA_SIGN 1.0, !- <none>
     SET ECON_FLOW_SCH_VAL = 0.0, !- <none>
   "
+  #########################################################################################################
   
     
   if controlleroutdoorair.getString(7).to_s.eql?("NoEconomizer")
@@ -451,6 +454,7 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
         SET NO_LOCK_OUT = True, !- <none>
       "
     end
+	#########################################################################################################
     main_body = main_body+"
       IF NO_LOCK_OUT, !- No lockout mode
       IF MDOT_OA_MAX < SMALLMASSFLOW, !- <none>
@@ -459,10 +463,11 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
       SET HIGHHUMCTRL = False, !- <none>
       ELSE, !- Running the economizer
       SET ECON_OP = True, !- <none>
-      IF OATmp > "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype}, !- <none>
+      IF OATmp_ORI > "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype}, !- <none>
       SET OA_SIGN = 1, !- <none>
       ENDIF, !- <none>
     "
+	#########################################################################################################
     if controlleroutdoorair.getString(7).to_s.eql?("DifferentialDryBulb")
       main_body = main_body+"
         IF OATmp > RETTmp, !- DifferentialDryBulb

--- a/fault_measures_2017/BiasedEconomizerSensorReturnT/measure.rb
+++ b/fault_measures_2017/BiasedEconomizerSensorReturnT/measure.rb
@@ -10,6 +10,7 @@
 require "#{File.dirname(__FILE__)}/resources/ControllerOutdoorAirFlow_T"
 
 $allchoices = '* ALL Controller:OutdoorAir *'
+$faulttype = 'RAT'				   
 
 # start the measure
 class BiasedEconomizerSensorReturnT < OpenStudio::Ruleset::WorkspaceUserScript

--- a/fault_measures_2017/BiasedEconomizerSensorReturnT/measure.xml
+++ b/fault_measures_2017/BiasedEconomizerSensorReturnT/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>biased_economizer_sensor_return_t</name>
   <uid>f1ba09fb-2903-45b2-838c-604b63fc4662</uid>
-  <version_id>8a38dbfc-55d9-4a4e-9cd4-8e6268c20361</version_id>
-  <version_modified>20190603T224604Z</version_modified>
+  <version_id>01c5c35a-7988-4bd2-98da-aa80e15ccde4</version_id>
+  <version_modified>20190605T150336Z</version_modified>
   <xml_checksum>B7427881</xml_checksum>
   <class_name>BiasedEconomizerSensorReturnT</class_name>
   <display_name>Biased Economizer Sensor: Return Temperature</display_name>
@@ -125,13 +125,13 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>5E53CF16</checksum>
+      <checksum>FCD23228</checksum>
     </file>
     <file>
       <filename>ControllerOutdoorAirFlow_T.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>460694A4</checksum>
+      <checksum>C2A71A53</checksum>
     </file>
   </files>
 </measure>

--- a/fault_measures_2017/BiasedEconomizerSensorReturnT/measure.xml
+++ b/fault_measures_2017/BiasedEconomizerSensorReturnT/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>biased_economizer_sensor_return_t</name>
   <uid>f1ba09fb-2903-45b2-838c-604b63fc4662</uid>
-  <version_id>f58b78fb-f2c4-4908-ae09-e6ab06baf0ce</version_id>
-  <version_modified>20190531T225602Z</version_modified>
+  <version_id>8a38dbfc-55d9-4a4e-9cd4-8e6268c20361</version_id>
+  <version_modified>20190603T224604Z</version_modified>
   <xml_checksum>B7427881</xml_checksum>
   <class_name>BiasedEconomizerSensorReturnT</class_name>
   <display_name>Biased Economizer Sensor: Return Temperature</display_name>
@@ -125,13 +125,13 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>E02DB20A</checksum>
+      <checksum>5E53CF16</checksum>
     </file>
     <file>
       <filename>ControllerOutdoorAirFlow_T.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>69E31B15</checksum>
+      <checksum>460694A4</checksum>
     </file>
   </files>
 </measure>

--- a/fault_measures_2017/BiasedEconomizerSensorReturnT/measure.xml
+++ b/fault_measures_2017/BiasedEconomizerSensorReturnT/measure.xml
@@ -2,8 +2,8 @@
   <schema_version>3.0</schema_version>
   <name>biased_economizer_sensor_return_t</name>
   <uid>f1ba09fb-2903-45b2-838c-604b63fc4662</uid>
-  <version_id>afceb73f-74e3-4949-8a48-46ff9a9a759b</version_id>
-  <version_modified>20190415T161742Z</version_modified>
+  <version_id>f58b78fb-f2c4-4908-ae09-e6ab06baf0ce</version_id>
+  <version_modified>20190531T225602Z</version_modified>
   <xml_checksum>B7427881</xml_checksum>
   <class_name>BiasedEconomizerSensorReturnT</class_name>
   <display_name>Biased Economizer Sensor: Return Temperature</display_name>
@@ -131,7 +131,7 @@
       <filename>ControllerOutdoorAirFlow_T.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>E7FE2EC1</checksum>
+      <checksum>69E31B15</checksum>
     </file>
   </files>
 </measure>

--- a/fault_measures_2017/BiasedEconomizerSensorReturnT/resources/ControllerOutdoorAirFlow_T.rb
+++ b/fault_measures_2017/BiasedEconomizerSensorReturnT/resources/ControllerOutdoorAirFlow_T.rb
@@ -169,7 +169,7 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
       SET PTmp = 101325.0, !- Zero pressure during warmup may crash the code
       ENDIF, !- <none>
       SET RETRH = @RhFnTdbWPb RETTmp RETHumRat PTmp, !- <none>
-      SET ORI_RETENTH = @HFnTdbRhPb RETTmp RETRH PTmp, !- <none>
+      SET ORI_RETENTH = @HFnTdbRhPb RETTmp_ORI RETRH PTmp, !- <none>
       SET ORI_RETHumRat = RETHumRat, !- <none>
       SET ORI_OAENTH = @HFnTdbW OATmp OAHumRat, !- <none>
       SET ORI_OAHumRat = OAHumRat, !- <none>

--- a/fault_measures_2017/BiasedEconomizerSensorReturnT/resources/ControllerOutdoorAirFlow_T.rb
+++ b/fault_measures_2017/BiasedEconomizerSensorReturnT/resources/ControllerOutdoorAirFlow_T.rb
@@ -159,7 +159,8 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
   end
   if bias_sensor.eql?("RET")
     main_body = main_body+"
-      SET RETTmp = "+name_cut(econ_choice)+"RETTemp1#{bias_sensor}_#{$faulttype}"+ret_str_num+"*AF_current_#{$faulttype}_#{oacontrollername}, !- <none>
+      SET RETTmp_ORI = "+name_cut(econ_choice)+"RETTemp1#{bias_sensor}_#{$faulttype}, !- <none>
+	  SET RETTmp = RETTmp_ORI"+ret_str_num+"*AF_current_#{$faulttype}_#{oacontrollername}, !- <none>
       SET RETHumRat = "+name_cut(econ_choice)+"RETOmega1#{bias_sensor}_#{$faulttype}, !- <none>
       SET OATmp = "+name_cut(econ_choice)+"OATTemp1#{bias_sensor}_#{$faulttype}, !- <none>
       SET OAHumRat = "+name_cut(econ_choice)+"OATOmega1#{bias_sensor}_#{$faulttype}, !- <none>

--- a/fault_measures_2017/BiasedEconomizerSensorReturnT/resources/ControllerOutdoorAirFlow_T.rb
+++ b/fault_measures_2017/BiasedEconomizerSensorReturnT/resources/ControllerOutdoorAirFlow_T.rb
@@ -158,6 +158,7 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
     oa_str_num = "#{oa_t_bias}"
   end
   if bias_sensor.eql?("RET")
+    ##########################################################################################################
     main_body = main_body+"
       SET RETTmp_ORI = "+name_cut(econ_choice)+"RETTemp1#{bias_sensor}_#{$faulttype}, !- <none>
 	  SET RETTmp = RETTmp_ORI"+ret_str_num+"*AF_current_#{$faulttype}_#{oacontrollername}, !- <none>
@@ -169,7 +170,8 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
       SET PTmp = 101325.0, !- Zero pressure during warmup may crash the code
       ENDIF, !- <none>
       SET RETRH = @RhFnTdbWPb RETTmp RETHumRat PTmp, !- <none>
-      SET ORI_RETENTH = @HFnTdbRhPb RETTmp_ORI RETRH PTmp, !- <none>
+	  SET RETRH_ORI = @RhFnTdbWPb RETTmp_ORI RETHumRat PTmp, !- <none>
+      SET ORI_RETENTH = @HFnTdbRhPb RETTmp_ORI RETRH_ORI PTmp, !- <none>
       SET ORI_RETHumRat = RETHumRat, !- <none>
       SET ORI_OAENTH = @HFnTdbW OATmp OAHumRat, !- <none>
       SET ORI_OAHumRat = OAHumRat, !- <none>
@@ -178,6 +180,7 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
       SET RETRHO = @RhoAirFnPbTdbW PTmp RETTmp RETHumRat, !- Calculate density before offsetting because density is not used by the controller
       SET OAENTH = @HFnTdbW OATmp OAHumRat, !- <none>
     "
+	############################################################################################################
   elsif bias_sensor.eql?("OA")
     main_body = main_body+"
 	  SET RETTmp = "+name_cut(econ_choice)+"RETTemp1#{bias_sensor}_#{$faulttype}, !- <none>
@@ -368,7 +371,7 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
       end
     end
   end
-  
+  ############################################################################################################
   main_body = main_body+"
     SET MIN_FRAC = @Max MIN_FRAC 0.0, !- <none>
     SET MIN_FRAC = @Min MIN_FRAC 1.0, !- <none>
@@ -376,15 +379,15 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
     SET TDiff = RETTmp-OATmp, !- <none>
     SET TDiff = @Abs TDiff, !- <none>
     IF TDiff > DELTASMALL, !- <none>
-    SET OA_SIGN = (RETTmp-"+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype})/(RETTmp-OATmp), !- Initialize the signal
+    SET OA_SIGN = (RETTmp_ORI-"+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype})/(RETTmp_ORI-OATmp), !- Initialize the signal
     ELSE, !- <none>
-    IF RETTmp < "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype} && RETTmp >= OATmp, !- <none>
+    IF RETTmp_ORI < "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype} && RETTmp_ORI >= OATmp, !- <none>
     SET OA_SIGN = -1, !- <none>
-    ELSEIF RETTmp < "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype} && RETTmp < OATmp, !- <none>
+    ELSEIF RETTmp_ORI < "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype} && RETTmp_ORI < OATmp, !- <none>
     SET OA_SIGN = 1, !- <none>
-    ELSEIF RETTmp >= "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype} && RETTmp >= OATmp,
+    ELSEIF RETTmp_ORI >= "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype} && RETTmp_ORI >= OATmp,
     SET OA_SIGN = 1, !- <none>
-    ELSEIF RETTmp >= "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype} && RETTmp < OATmp,
+    ELSEIF RETTmp_ORI >= "+name_cut(econ_choice)+"MASetPoint1#{bias_sensor}_#{$faulttype} && RETTmp_ORI < OATmp,
     SET OA_SIGN = -1, !- <none>
     ENDIF, !- <none>
     ENDIF, !- <none>
@@ -392,7 +395,7 @@ def econ_t_sensor_bias_ems_main_body(workspace, bias_sensor, controlleroutdoorai
     SET OA_SIGN = @Min OA_SIGN 1.0, !- <none>
     SET ECON_FLOW_SCH_VAL = 0.0, !- <none>
   "
-  
+  ############################################################################################################  
     
   if controlleroutdoorair.getString(7).to_s.eql?("NoEconomizer")
     main_body = main_body+"


### PR DESCRIPTION
Refer to https://github.com/NREL/OpenStudio-fault-models/issues/64#issue-448286338 for detail info on the issue.

Biased Economizer Sensor Fault: Outdoor Air Temperature Sensor
BEFORE FIX,
![image](https://user-images.githubusercontent.com/26775789/58967617-bf2d9300-8771-11e9-8129-fc3d35f983fa.png)
AFTER FIX,
![image](https://user-images.githubusercontent.com/26775789/58967632-c8b6fb00-8771-11e9-9722-9e35da4b1b8d.png)

Biased Economizer Sensor Fault: Return Air Temperature Sensor
BEFORE FIX,
![image](https://user-images.githubusercontent.com/26775789/58967667-d53b5380-8771-11e9-867f-6294708e7935.png)
AFTER FIX,
![image](https://user-images.githubusercontent.com/26775789/58967684-df5d5200-8771-11e9-847a-0e13172e5dfe.png)
